### PR TITLE
etags are supposed to have quotes around them according to rfc7232

### DIFF
--- a/src/Marvin.Cache.Headers/HttpCacheHeadersMiddleware.cs
+++ b/src/Marvin.Cache.Headers/HttpCacheHeadersMiddleware.cs
@@ -672,7 +672,7 @@ namespace Marvin.Cache.Headers
                 var hex = BitConverter.ToString(hash);
                 ret = hex.Replace("-", "");
             }
-            return ret;
+            return $"\"{ret}\"";
         }
 
         private static byte[] Combine(byte[] a, byte[] b)


### PR DESCRIPTION
When I was writing a failing test for another issue, I used this code:
```
client.DefaultRequestHeaders.IfNoneMatch.Add(new EntityTagHeaderValue(etag, false));
```

When I populated `etag` with the generated response, it crashed claiming the format was incorrect. After investigating, Microsoft was right ;) Apparently the format needs quotes around it, both in the response as in the requests.

This small change fixes this. On my todo list I plan to make the etag generator injectable in a future PR, but this is an easy fix already :)