### PR TITLE
feat: support method level cache-control

### DIFF
--- a/sample/Marvin.Cache.Headers.Sample/Controllers/ValuesController.cs
+++ b/sample/Marvin.Cache.Headers.Sample/Controllers/ValuesController.cs
@@ -11,8 +11,8 @@ namespace Marvin.Cache.Headers.Sample.Controllers
     {
         // GET api/values
         [HttpGet]
-        [HttpCacheExpiration(cacheLocation: CacheLocation.Public, maxAge: 99999)]
-        [HttpCacheValidation(addMustRevalidate: true)]
+        [HttpCacheExpiration(CacheLocation = CacheLocation.Public, MaxAge = 99999)]
+        [HttpCacheValidation(AddMustRevalidate = true)]
         public IEnumerable<string> Get()
         {
             return new[] { "value1", "value2" };
@@ -20,7 +20,7 @@ namespace Marvin.Cache.Headers.Sample.Controllers
 
         // GET api/values/5
         [HttpGet("{id}")]
-        [HttpCacheExpiration(cacheLocation: CacheLocation.Private, maxAge: 1337)]
+        [HttpCacheExpiration(CacheLocation = CacheLocation.Private, MaxAge = 1337)]
         [HttpCacheValidation]
         public string Get(int id)
         {

--- a/sample/Marvin.Cache.Headers.Sample/Controllers/ValuesController.cs
+++ b/sample/Marvin.Cache.Headers.Sample/Controllers/ValuesController.cs
@@ -11,6 +11,8 @@ namespace Marvin.Cache.Headers.Sample.Controllers
     {
         // GET api/values
         [HttpGet]
+        [HttpCacheExpiration(cacheLocation: CacheLocation.Public, maxAge: 99999)]
+        [HttpCacheValidation(addMustRevalidate: true)]
         public IEnumerable<string> Get()
         {
             return new[] { "value1", "value2" };
@@ -18,6 +20,8 @@ namespace Marvin.Cache.Headers.Sample.Controllers
 
         // GET api/values/5
         [HttpGet("{id}")]
+        [HttpCacheExpiration(cacheLocation: CacheLocation.Private, maxAge: 1337)]
+        [HttpCacheValidation]
         public string Get(int id)
         {
             return "value";

--- a/src/Marvin.Cache.Headers/HttpCacheExpirationAttribute.cs
+++ b/src/Marvin.Cache.Headers/HttpCacheExpirationAttribute.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc.Filters;
+
+namespace Marvin.Cache.Headers
+{
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method)]
+    public class HttpCacheExpirationAttribute : Attribute, IAsyncResourceFilter
+    {
+        private readonly ExpirationModelOptions _expirationModelOptions;
+
+        /// <param name="maxAge">
+        /// Maximum age, in seconds, after which a response expires. Has an effect on Expires & on the max-age directive
+        /// of the Cache-Control header.
+        ///
+        /// Defaults to 60.
+        /// </param>
+        /// <param name="sharedMaxAge">
+        /// Maximum age, in seconds, after which a response expires for shared caches.  If included,
+        /// a shared cache should use this value rather than the max-age value. (s-maxage directive)
+        ///
+        /// Not set by default.
+        /// </param>
+        /// <param name="cacheLocation">
+        /// The location where a response can be cached.  Public means it can be cached by both
+        /// public (shared) and private (client) caches.  Private means it can only be cached by
+        /// private (client) caches. (public or private directive)
+        ///
+        /// Defaults to public.
+        /// </param>
+        /// <param name="addNoStoreDirective">
+        /// When true, the no-store directive is included in the Cache-Control header.
+        /// When this directive is included, a cache must not store any part of the message,
+        /// mostly for confidentiality reasonse.
+        ///
+        /// Defaults to false.
+        /// </param>
+        /// <param name="addNoTransformDirective">
+        /// When true, the no-transform directive is included in the Cache-Control header.
+        /// When this directive is included, a cache must not convert the media type of the
+        /// response body.
+        ///
+        /// Defaults to false.
+        /// </param>
+        public HttpCacheExpirationAttribute(
+            int maxAge = 60,
+            int sharedMaxAge = -1,
+            CacheLocation cacheLocation = CacheLocation.Public,
+            bool addNoStoreDirective = false,
+            bool addNoTransformDirective = false)
+        {
+            _expirationModelOptions = new ExpirationModelOptions
+            {
+                MaxAge = maxAge,
+                SharedMaxAge = sharedMaxAge == -1 ? new int?() : sharedMaxAge,
+                CacheLocation = cacheLocation,
+                AddNoStoreDirective = addNoStoreDirective,
+                AddNoTransformDirective = addNoTransformDirective
+            };
+        }
+
+        public async Task OnResourceExecutionAsync(ResourceExecutingContext context, ResourceExecutionDelegate next)
+        {
+            await next();
+
+            context.HttpContext.Items[HttpCacheHeadersMiddleware.ContextItemsExpirationModelOptions] = _expirationModelOptions;
+        }
+    }
+}

--- a/src/Marvin.Cache.Headers/HttpCacheExpirationAttribute.cs
+++ b/src/Marvin.Cache.Headers/HttpCacheExpirationAttribute.cs
@@ -7,63 +7,68 @@ namespace Marvin.Cache.Headers
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method)]
     public class HttpCacheExpirationAttribute : Attribute, IAsyncResourceFilter
     {
-        private readonly ExpirationModelOptions _expirationModelOptions;
+        private readonly Lazy<ExpirationModelOptions> _expirationModelOptions;
 
-        /// <param name="maxAge">
+        /// <summary>
         /// Maximum age, in seconds, after which a response expires. Has an effect on Expires & on the max-age directive
         /// of the Cache-Control header.
         ///
         /// Defaults to 60.
-        /// </param>
-        /// <param name="sharedMaxAge">
+        /// </summary>
+        public int MaxAge { get; set; } = 60;
+
+        /// <summary>
         /// Maximum age, in seconds, after which a response expires for shared caches.  If included,
         /// a shared cache should use this value rather than the max-age value. (s-maxage directive)
         ///
         /// Not set by default.
-        /// </param>
-        /// <param name="cacheLocation">
+        /// </summary>
+        public int? SharedMaxAge { get; set; }
+
+        /// <summary>
         /// The location where a response can be cached.  Public means it can be cached by both
         /// public (shared) and private (client) caches.  Private means it can only be cached by
         /// private (client) caches. (public or private directive)
         ///
         /// Defaults to public.
-        /// </param>
-        /// <param name="addNoStoreDirective">
+        /// </summary>
+        public CacheLocation CacheLocation { get; set; } = CacheLocation.Public;
+
+        /// <summary>
         /// When true, the no-store directive is included in the Cache-Control header.
         /// When this directive is included, a cache must not store any part of the message,
         /// mostly for confidentiality reasonse.
         ///
         /// Defaults to false.
-        /// </param>
-        /// <param name="addNoTransformDirective">
+        /// </summary>
+        public bool AddNoStoreDirective { get; set; } = false;
+
+        /// <summary>
         /// When true, the no-transform directive is included in the Cache-Control header.
         /// When this directive is included, a cache must not convert the media type of the
         /// response body.
         ///
         /// Defaults to false.
-        /// </param>
-        public HttpCacheExpirationAttribute(
-            int maxAge = 60,
-            int sharedMaxAge = -1,
-            CacheLocation cacheLocation = CacheLocation.Public,
-            bool addNoStoreDirective = false,
-            bool addNoTransformDirective = false)
+        /// </summary>
+        public bool AddNoTransformDirective { get; set; } = false;
+
+        public HttpCacheExpirationAttribute()
         {
-            _expirationModelOptions = new ExpirationModelOptions
+            _expirationModelOptions = new Lazy<ExpirationModelOptions>(() => new ExpirationModelOptions
             {
-                MaxAge = maxAge,
-                SharedMaxAge = sharedMaxAge == -1 ? new int?() : sharedMaxAge,
-                CacheLocation = cacheLocation,
-                AddNoStoreDirective = addNoStoreDirective,
-                AddNoTransformDirective = addNoTransformDirective
-            };
+                MaxAge = MaxAge,
+                SharedMaxAge = SharedMaxAge,
+                CacheLocation = CacheLocation,
+                AddNoStoreDirective = AddNoStoreDirective,
+                AddNoTransformDirective = AddNoTransformDirective
+            });
         }
 
         public async Task OnResourceExecutionAsync(ResourceExecutingContext context, ResourceExecutionDelegate next)
         {
             await next();
 
-            context.HttpContext.Items[HttpCacheHeadersMiddleware.ContextItemsExpirationModelOptions] = _expirationModelOptions;
+            context.HttpContext.Items[HttpCacheHeadersMiddleware.ContextItemsExpirationModelOptions] = _expirationModelOptions.Value;
         }
     }
 }

--- a/src/Marvin.Cache.Headers/HttpCacheValidationAttribute.cs
+++ b/src/Marvin.Cache.Headers/HttpCacheValidationAttribute.cs
@@ -1,0 +1,86 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc.Filters;
+
+namespace Marvin.Cache.Headers
+{
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method)]
+    public class HttpCacheValidationAttribute : Attribute, IAsyncResourceFilter
+    {
+        private readonly ValidationModelOptions _validationModelOptions;
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="vary">
+        /// A case-insensitive list of headers from the request to take into account as differentiator
+        /// between requests (eg: for generating ETags)
+        ///
+        /// Defaults to Accept, Accept-Language, Accept-Encoding.  * indicates all request headers can be taken into account.
+        /// </param>
+        /// <param name="varyByAll">
+        /// Indicates that all request headers are taken into account as differentiator.
+        /// When set to true, this is the same as Vary *.  The Vary list will thus be ignored.
+        ///
+        /// Note that a Vary field value of "*" implies that a cache cannot determine
+        /// from the request headers of a subsequent request whether this response is
+        /// the appropriate representation.  This should thus only be set to true for
+        /// exceptional cases.
+        ///
+        /// Defaults to false.
+        /// </param>
+        /// <param name="addNoCache">
+        /// When true, the no-cache directive is added to the Cache-Control header.
+        /// This indicates to a cache that the response should not be used for subsequent requests
+        /// without successful revalidation with the origin server.
+        ///
+        /// Defaults to false.
+        /// </param>
+        /// <param name="addMustRevalidate">
+        /// When true, the must-revalidate directive is added to the Cache-Control header.
+        /// This tells a cache that if a response becomes stale, ie: it's expired, revalidation has to happen.
+        /// By adding this directive, we can force revalidation by the cache even if the client
+        /// has decided that stale responses are for a specified amount of time (which a client can
+        /// do by setting the max-stale directive).
+        ///
+        /// Defaults to false.
+        /// </param>
+        /// <param name="addProxyRevalidate">
+        /// When true, the proxy-revalidate directive is added to the Cache-Control header.
+        /// Exactly the same as must-revalidate, but only only for shared caches.
+        /// So: this tells a shared cache that if a response becomes stale, ie: it's expired, revalidation has to happen.
+        /// By adding this directive, we can force revalidation by the cache even if the client
+        /// has decided that stale responses are for a specified amount of time (which a client can
+        /// do by setting the max-stale directive).
+        ///
+        /// Defaults to false.
+        /// </param>
+        public HttpCacheValidationAttribute(
+            string vary = null,
+            bool varyByAll = false,
+            bool addNoCache = false,
+            bool addMustRevalidate = false,
+            bool addProxyRevalidate = false)
+        {
+            _validationModelOptions = new ValidationModelOptions
+            {
+                Vary = string.IsNullOrWhiteSpace(vary)
+                    ? new List<string> { "Accept", "Accept-Language", "Accept-Encoding" }
+                    : vary.Split(new []{","}, StringSplitOptions.RemoveEmptyEntries).ToList(),
+                VaryByAll = varyByAll,
+                AddNoCache = addNoCache,
+                AddMustRevalidate = addMustRevalidate,
+                AddProxyRevalidate = addProxyRevalidate
+            };
+        }
+
+        public async Task OnResourceExecutionAsync(ResourceExecutingContext context, ResourceExecutionDelegate next)
+        {
+            await next();
+
+            context.HttpContext.Items[HttpCacheHeadersMiddleware.ContextItemsValidationModelOptions] = _validationModelOptions;
+        }
+    }
+}

--- a/src/Marvin.Cache.Headers/Marvin.Cache.Headers.csproj
+++ b/src/Marvin.Cache.Headers/Marvin.Cache.Headers.csproj
@@ -15,7 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="1.0.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="1.0.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="1.0.2" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="1.0.2" />
     <PackageReference Include="Microsoft.Net.Http.Headers" Version="1.0.2" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="1.0.2" />

--- a/src/Marvin.Cache.Headers/Marvin.Cache.Headers.csproj
+++ b/src/Marvin.Cache.Headers/Marvin.Cache.Headers.csproj
@@ -15,6 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="1.0.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="1.0.3" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="1.0.2" />
     <PackageReference Include="Microsoft.Net.Http.Headers" Version="1.0.2" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="1.0.2" />

--- a/test/Marvin.Cache.Headers.Test/DefaultConfigurationFacts.cs
+++ b/test/Marvin.Cache.Headers.Test/DefaultConfigurationFacts.cs
@@ -3,7 +3,6 @@
 
 using System.Linq;
 using System.Net;
-using System.Net.Http.Headers;
 using System.Threading.Tasks;
 using Marvin.Cache.Headers.Test.TestStartups;
 using Microsoft.AspNetCore.Hosting;

--- a/test/Marvin.Cache.Headers.Test/Marvin.Cache.Headers.Test.csproj
+++ b/test/Marvin.Cache.Headers.Test/Marvin.Cache.Headers.Test.csproj
@@ -21,6 +21,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\sample\Marvin.Cache.Headers.Sample\Marvin.Cache.Headers.Sample.csproj" />
     <ProjectReference Include="..\..\src\Marvin.Cache.Headers\Marvin.Cache.Headers.csproj" />
   </ItemGroup>
 

--- a/test/Marvin.Cache.Headers.Test/MvcConfigurationFacts.cs
+++ b/test/Marvin.Cache.Headers.Test/MvcConfigurationFacts.cs
@@ -1,0 +1,45 @@
+﻿// Any comments, input: @KevinDockx
+// Any issues, requests: https://github.com/KevinDockx/HttpCacheHeaders
+
+using System.Linq;
+using System.Threading.Tasks;
+using Marvin.Cache.Headers.Sample;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Net.Http.Headers;
+using Xunit;
+
+namespace Marvin.Cache.Headers.Test
+{
+    public class MvcConfigurationFacts
+    {
+        private readonly IWebHostBuilder _hostBuilder = new WebHostBuilder()
+            .UseStartup<Startup>();
+
+        private readonly TestServer _server;
+
+        public MvcConfigurationFacts()
+        {
+            _server = new TestServer(_hostBuilder);
+        }
+
+        [Fact]
+        public async Task Adds_Default_Validation_And_ExpirationHeaders()
+        {
+            using (var client = _server.CreateClient())
+            {
+                var response = await client.GetAsync("/api/values");
+
+                Assert.True(response.IsSuccessStatusCode);
+
+                Assert.Contains(response.Headers, pair => pair.Key == HeaderNames.CacheControl && pair.Value.First() == "public, must-revalidate, max-age=99999");
+
+                var response2 = await client.GetAsync("/api/values/1");
+
+                Assert.True(response2.IsSuccessStatusCode);
+
+                Assert.Contains(response2.Headers, pair => pair.Key == HeaderNames.CacheControl && pair.Value.First() == "max-age=1337, private");
+            }
+        }
+    }
+}


### PR DESCRIPTION
You can now override the global cache settings on a class or method level using `[HttpCacheExpiration]` and `[HttpCacheValidation]`

I have added a test for this as well.

Some remarks: It takes an extra dependency on `Microsoft.AspNetCore.Mvc.Abstractions`, it does however stay `netstandard1.6`

Although, I would propose to take this moment to upgrade all dependencies to the latest 2.1? (Which does however increase it to target `netstandard2.0`) Your opinion?