### PR TITLE
WIP: Allow modular components

### DIFF
--- a/src/Marvin.Cache.Headers/Extensions/ServicesExtensions.cs
+++ b/src/Marvin.Cache.Headers/Extensions/ServicesExtensions.cs
@@ -5,6 +5,7 @@ using Marvin.Cache.Headers;
 using Marvin.Cache.Headers.Interfaces;
 using Marvin.Cache.Headers.Stores;
 using System;
+using Marvin.Cache.Header;
 
 namespace Microsoft.Extensions.DependencyInjection
 {
@@ -13,29 +14,13 @@ namespace Microsoft.Extensions.DependencyInjection
     /// </summary>
     public static class ServicesExtensions
     {
-        public static IServiceCollection AddHttpCacheHeaders(this IServiceCollection services)
-        {
-            AddInMemoryValidationValueStore(services);
-
-            return services;
-        }
-
         public static IServiceCollection AddHttpCacheHeaders(
             this IServiceCollection services,
-            Action<ExpirationModelOptions> configureExpirationModelOptions)
+            IValidationValueStore store = null,
+            IStoreKeyGenerator storeKeyGenerator = null)
         {
-            AddConfigureExpirationModelOptions(services, configureExpirationModelOptions);
-            AddInMemoryValidationValueStore(services);
-
-            return services;
-        }
-
-        public static IServiceCollection AddHttpCacheHeaders(
-            this IServiceCollection services,
-            Action<ValidationModelOptions> configureValidationModelOptions)
-        {
-            AddConfigureValidationModelOptions(services, configureValidationModelOptions);
-            AddInMemoryValidationValueStore(services);
+            AddValidationValueStore(services, store);
+            AddStoreKeyGenerator(services, storeKeyGenerator);
 
             return services;
         }
@@ -43,23 +28,79 @@ namespace Microsoft.Extensions.DependencyInjection
         public static IServiceCollection AddHttpCacheHeaders(
             this IServiceCollection services,
             Action<ExpirationModelOptions> configureExpirationModelOptions,
-            Action<ValidationModelOptions> configureValidationModelOptions)
+            IValidationValueStore store = null,
+            IStoreKeyGenerator storeKeyGenerator = null)
         {
             AddConfigureExpirationModelOptions(services, configureExpirationModelOptions);
-            AddConfigureValidationModelOptions(services, configureValidationModelOptions);
-            AddInMemoryValidationValueStore(services);
+
+            AddValidationValueStore(services, store);
+            AddStoreKeyGenerator(services, storeKeyGenerator);
 
             return services;
         }
 
-        private static void AddInMemoryValidationValueStore(IServiceCollection services)
+        public static IServiceCollection AddHttpCacheHeaders(
+            this IServiceCollection services,
+            Action<ValidationModelOptions> configureValidationModelOptions,
+            IValidationValueStore store = null,
+            IStoreKeyGenerator storeKeyGenerator = null)
+        {
+            AddConfigureValidationModelOptions(services, configureValidationModelOptions);
+
+            AddValidationValueStore(services, store);
+            AddStoreKeyGenerator(services, storeKeyGenerator);
+
+            return services;
+        }
+
+        public static IServiceCollection AddHttpCacheHeaders(
+            this IServiceCollection services,
+            Action<ExpirationModelOptions> configureExpirationModelOptions,
+            Action<ValidationModelOptions> configureValidationModelOptions,
+            IValidationValueStore store = null,
+            IStoreKeyGenerator storeKeyGenerator = null)
+        {
+            AddConfigureExpirationModelOptions(services, configureExpirationModelOptions);
+            AddConfigureValidationModelOptions(services, configureValidationModelOptions);
+
+            AddValidationValueStore(services, store);
+            AddStoreKeyGenerator(services, storeKeyGenerator);
+
+            return services;
+        }
+
+        private static void AddValidationValueStore(
+            IServiceCollection services,
+            IValidationValueStore store)
         {
             if (services == null)
             {
                 throw new ArgumentNullException(nameof(services));
             }
 
-            services.Add(ServiceDescriptor.Singleton<IValidationValueStore, InMemoryValidationValueStore>());
+            if (store == null)
+            {
+                store = new InMemoryValidationValueStore();
+            }
+
+            services.Add(ServiceDescriptor.Singleton(typeof(IValidationValueStore), store));
+        }
+
+        private static void AddStoreKeyGenerator(
+            IServiceCollection services,
+            IStoreKeyGenerator storeKeyGenerator)
+        {
+            if (services == null)
+            {
+                throw new ArgumentNullException(nameof(services));
+            }
+
+            if (storeKeyGenerator == null)
+            {
+                storeKeyGenerator = new StoreKeyGenerator();
+            }
+
+            services.Add(ServiceDescriptor.Singleton(typeof(IStoreKeyGenerator), storeKeyGenerator));
         }
 
         private static void AddConfigureExpirationModelOptions(

--- a/src/Marvin.Cache.Headers/HttpContextExtensions.cs
+++ b/src/Marvin.Cache.Headers/HttpContextExtensions.cs
@@ -1,0 +1,20 @@
+﻿using Microsoft.AspNetCore.Http;
+
+namespace Marvin.Cache.Headers
+{
+    internal static class HttpContextExtensions
+    {
+        internal static readonly string ContextItemsExpirationModelOptions = "HttpCacheHeadersMiddleware-ExpirationModelOptions";
+        internal static readonly string ContextItemsValidationModelOptions = "HttpCacheHeadersMiddleware-ValidationModelOptions";
+
+        public static ExpirationModelOptions ExpirationModelOptionsOrDefault(this HttpContext httpContext, ExpirationModelOptions @default) =>
+            httpContext.Items.ContainsKey(ContextItemsExpirationModelOptions)
+                ? (ExpirationModelOptions)httpContext.Items[ContextItemsExpirationModelOptions]
+                : @default;
+
+        public static ValidationModelOptions ValidationModelOptionsOrDefault(this HttpContext httpContext, ValidationModelOptions @default) =>
+            httpContext.Items.ContainsKey(ContextItemsValidationModelOptions)
+                ? (ValidationModelOptions)httpContext.Items[ContextItemsValidationModelOptions]
+                : @default;
+    }
+}

--- a/src/Marvin.Cache.Headers/Interfaces/IStoreKeyGenerator.cs
+++ b/src/Marvin.Cache.Headers/Interfaces/IStoreKeyGenerator.cs
@@ -1,0 +1,66 @@
+﻿// Any comments, input: @KevinDockx
+// Any issues, requests: https://github.com/KevinDockx/HttpCacheHeaders
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Marvin.Cache.Headers;
+using Marvin.Cache.Headers.Interfaces;
+using Microsoft.AspNetCore.Http;
+
+namespace Marvin.Cache.Headers.Interfaces
+{
+    public interface IStoreKeyGenerator
+    {
+        Task<RequestKey> GenerateStoreKey(
+            HttpRequest request,
+            ValidationModelOptions validationModelOptions);
+    }
+}
+
+namespace Marvin.Cache.Header
+{
+    public class StoreKeyGenerator : IStoreKeyGenerator
+    {
+        public Task<RequestKey> GenerateStoreKey(
+            HttpRequest request,
+            ValidationModelOptions validationModelOptions)
+        {
+            // generate a key to store the entity tag with in the entity tag store
+            List<string> requestHeaderValues;
+
+            // get the request headers to take into account (VaryBy) & take
+            // their values
+            if (validationModelOptions.VaryByAll)
+            {
+                requestHeaderValues = request
+                    .Headers
+                    .SelectMany(h => h.Value)
+                    .ToList();
+            }
+            else
+            {
+                requestHeaderValues = request
+                    .Headers
+                    .Where(x => validationModelOptions.Vary.Any(h => h.Equals(x.Key, StringComparison.CurrentCultureIgnoreCase)))
+                    .SelectMany(h => h.Value)
+                    .ToList();
+            }
+
+            // get the resoure path
+            var resourcePath = request.Path.ToString();
+
+            // get the query string
+            var queryString = request.QueryString.ToString();
+
+            // combine these
+            return Task.FromResult(new RequestKey
+            {
+                { nameof(resourcePath), resourcePath },
+                { nameof(queryString), queryString },
+                { nameof(requestHeaderValues), string.Join("-", requestHeaderValues)}
+            });
+        }
+    }
+}


### PR DESCRIPTION
This is a proposal to support cases: 
* Support injecting custom store for validation/ETags #11 
* Allow custom GenerateKey method #53
* Allow configuring that the eTags generated should be considered weak eTags. #22 
* Allow custom ETag functions #6
* Allow multiple datetime formats? #29

Because of the small impact of https://github.com/KevinDockx/HttpCacheHeaders/issues/54 it's also in here because I branched of that one.

I would propose to continue this WIP and perhaps make it a major release when it's possible for someone to provide all moving parts like this?

Right now my idea was to give the `AddHttpCacheHeaders` optional parameters to provide your own implementations (using named parameters), if people don't provide it we fall back on the default implementation as it is today.