### PR TITLE
Verified operation of generating ETags from HttpContext.

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,15 @@ public interface IStoreKeyGenerator
 
 ## IETagGenerator
 
-You can inject an IETagGenerator-implementing class to modify how ETags are generated (ETags are part of a ValidatorValue). The default implementation (DefaultStrongETagGenerator) generates strong Etags from the request key + response body (MD5 hjsh from combined bytes). 
+You can inject an IETagGenerator-implementing class to modify how ETags are generated (ETags are part 
+of a ValidatorValue). Etags provided by the GenerateETag method accepting the *httpContext* are given priority
+over Etags generated from the GenerateETag method accepting *storeKey* and *responseBodycontent*.
+
+The default implementation (DefaultStrongETagGenerator) GenerateETag method that 
+accepts a HttpConext checks the context's Items dictionary for the key `ETag` (e.g., `httpContext.Items["ETag"]`).
+If the key is available, the value is used as an Etag. This is useful if you want to 
+use an Etag from your persistence layer (e.g., the _etag property of a CosmosDb document). 
+The second GenerateETag method generates strong Etags from the request key + response body (MD5 hash from combined bytes). 
 
 ```
 /// <summary>
@@ -124,11 +132,13 @@ You can inject an IETagGenerator-implementing class to modify how ETags are gene
 public interface IETagGenerator
 {
     Task<ETag> GenerateETag(
+        HttpContext httpContext);
+
+    Task<ETag> GenerateETag(
         StoreKey storeKey,
         string responseBodyContent);
 }
 ```
-
 
 ## IDateParser 
 

--- a/src/Marvin.Cache.Headers/DefaultStrongETagGenerator.cs
+++ b/src/Marvin.Cache.Headers/DefaultStrongETagGenerator.cs
@@ -6,26 +6,11 @@ using System.Text;
 using System.Threading.Tasks;
 using Marvin.Cache.Headers.Extensions;
 using Marvin.Cache.Headers.Interfaces;
-using Microsoft.AspNetCore.Http;
 
 namespace Marvin.Cache.Headers
 {
     public class DefaultStrongETagGenerator : IETagGenerator
     {
-        // By default using the HTTP context to acquire an ETag is not available. This
-        // method must always be provided by the consumer of this package.
-        public virtual Task<ETag> GenerateETag(HttpContext httpContext)
-        {
-            if (httpContext.Items.ContainsKey("ETag"))
-            {
-                return Task.FromResult(new ETag(httpContext.Items["ETag"] as string));
-            }
-            else
-            {
-                return Task.FromResult(default(ETag));
-            }
-        }
-
         // Key = generated from request URI & headers (if VaryBy is set, only use those headers)
         // ETag itself is generated from the key + response body (strong ETag)
         public virtual Task<ETag> GenerateETag(
@@ -48,6 +33,5 @@ namespace Marvin.Cache.Headers
             Buffer.BlockCopy(b, 0, c, a.Length, b.Length);
             return c;
         }
-
     }
 }

--- a/src/Marvin.Cache.Headers/DefaultStrongETagGenerator.cs
+++ b/src/Marvin.Cache.Headers/DefaultStrongETagGenerator.cs
@@ -6,14 +6,29 @@ using System.Text;
 using System.Threading.Tasks;
 using Marvin.Cache.Headers.Extensions;
 using Marvin.Cache.Headers.Interfaces;
+using Microsoft.AspNetCore.Http;
 
 namespace Marvin.Cache.Headers
 {
     public class DefaultStrongETagGenerator : IETagGenerator
     {
+        // By default using the HTTP context to acquire an ETag is not available. This
+        // method must always be provided by the consumer of this package.
+        public virtual Task<ETag> GenerateETag(HttpContext httpContext)
+        {
+            if (httpContext.Items.ContainsKey("ETag"))
+            {
+                return Task.FromResult(new ETag(httpContext.Items["ETag"] as string));
+            }
+            else
+            {
+                return Task.FromResult(default(ETag));
+            }
+        }
+
         // Key = generated from request URI & headers (if VaryBy is set, only use those headers)
         // ETag itself is generated from the key + response body (strong ETag)
-        public Task<ETag> GenerateETag(
+        public virtual Task<ETag> GenerateETag(
             StoreKey storeKey,
             string responseBodyContent)
         {
@@ -33,5 +48,6 @@ namespace Marvin.Cache.Headers
             Buffer.BlockCopy(b, 0, c, a.Length, b.Length);
             return c;
         }
+
     }
 }

--- a/src/Marvin.Cache.Headers/DefaultValidatorValueGenerator.cs
+++ b/src/Marvin.Cache.Headers/DefaultValidatorValueGenerator.cs
@@ -1,0 +1,119 @@
+﻿// Any comments, input: @KevinDockx
+// Any issues, requests: https://github.com/KevinDockx/HttpCacheHeaders
+
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Marvin.Cache.Headers.Interfaces;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Net.Http.Headers;
+
+namespace Marvin.Cache.Headers
+{
+    public class DefaultValidatorValueGenerator : IValidatorValueGenerator
+    {
+        public virtual async Task<ValidatorValue> Generate(StoreKey storeKey, HttpContext httpContext, IETagGenerator eTagGenerator = null)
+        {
+            ETag eTag = await GetETagFromHttpContext(httpContext);
+            DateTimeOffset? lastModified = await GetLastModifiedFromHttpContext(httpContext);
+
+            // If we do not have an etag value at this point, and we can read the response body,
+            // initiate the process of generating an etag.
+            if ((eTag == null) && (httpContext.Response.Body.CanRead))
+            {
+                // if no ETag generator has been supplied, use the default etag generator.
+                if (eTagGenerator == null)
+                {
+                    eTagGenerator = new DefaultStrongETagGenerator();
+                }
+
+                // get the response bytes
+                if (httpContext.Response.Body.CanSeek)
+                {
+                    httpContext.Response.Body.Position = 0;
+                }
+
+                var responseBodyContent = new StreamReader(httpContext.Response.Body).ReadToEnd();
+
+                // Calculate the ETag to store in the store.
+                eTag = await eTagGenerator.GenerateETag(storeKey, responseBodyContent);
+            }
+
+            if (eTag != null)
+            {
+                // Ensure we have a valid Last-Modified value.
+                if (!lastModified.HasValue)
+                {
+                    lastModified = GetUtcNowWithoutMilliseconds();
+                }
+                else
+                {
+                    lastModified = GetUtcNowWithoutMilliseconds(lastModified.Value);
+                }
+
+                return new ValidatorValue(eTag, lastModified.Value);
+            }
+
+            // if no etag has been generated, it should never be cached.
+            return null;
+        }
+        
+        // By default using the HTTP context to acquire an ETag is not available. This
+        // method must always be provided by the consumer of this package.
+        protected virtual Task<ETag> GetETagFromHttpContext(HttpContext httpContext, string key = HeaderNames.ETag)
+        {
+            if ((httpContext != null) && (httpContext.Items.ContainsKey(key)))
+            {
+                return Task.FromResult(new ETag(httpContext.Items[key] as string));
+            }
+
+            return Task.FromResult(default(ETag));
+        }
+
+        // By default using the HTTP context to acquire an ETag is not available. This
+        // method must always be provided by the consumer of this package.
+        protected virtual Task<DateTimeOffset?> GetLastModifiedFromHttpContext(HttpContext httpContext, string key = HeaderNames.LastModified)
+        {
+            if ((httpContext != null) && (httpContext.Items.ContainsKey(key)))
+            {
+                var lastModified = httpContext.Items[key];
+
+                if (lastModified is DateTimeOffset)
+                {
+                    return Task.FromResult((DateTimeOffset?)lastModified);
+                }
+                else if (lastModified is DateTime)
+                {
+                    return Task.FromResult((DateTimeOffset?)new DateTimeOffset((DateTime)lastModified));
+
+                }
+                else if (lastModified is string)
+                {
+                    if (DateTimeOffset.TryParse((string)lastModified, out var parsedLastModified))
+                    {
+                        return Task.FromResult((DateTimeOffset?)parsedLastModified);
+                    }
+                }
+            }
+
+            return Task.FromResult((DateTimeOffset?)null);
+        }
+
+        protected static DateTimeOffset GetUtcNowWithoutMilliseconds()
+        {
+            return GetUtcNowWithoutMilliseconds(DateTimeOffset.UtcNow);
+        }
+
+        protected static DateTimeOffset GetUtcNowWithoutMilliseconds(DateTimeOffset dt)
+        {
+            return new DateTimeOffset(
+                dt.Year,
+                dt.Month,
+                dt.Day,
+                dt.Hour,
+                dt.Minute,
+                dt.Second,
+                dt.Offset);
+        }
+    }
+}

--- a/src/Marvin.Cache.Headers/Domain/ETag.cs
+++ b/src/Marvin.Cache.Headers/Domain/ETag.cs
@@ -14,6 +14,33 @@ namespace Marvin.Cache.Headers
             Value = value;
         }
 
+        // Create an ETag object from the given value and determine if the ETag
+        // is string of weak. If the strength of the ETag cannot be determined,
+        // the default Etag type is applied.
+        public ETag(string value, ETagType defaultETagType = ETagType.Weak)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                Value = null;
+                ETagType = ETagType.Weak;
+            }
+            else if (value.StartsWith("W\"") && value.EndsWith("\"")) 
+            {
+                Value = value.Substring(2, value.Length - 3);
+                ETagType = ETagType.Weak;
+            }
+            else if (value.StartsWith("\"") && value.EndsWith("\""))
+            {
+                Value = value.Substring(1, value.Length - 2);
+                ETagType = ETagType.Strong;
+            }
+            else
+            {
+                Value = value;
+                ETagType = defaultETagType;
+            }
+        }
+
         public override string ToString()
         {
             switch (ETagType)

--- a/src/Marvin.Cache.Headers/Domain/ValidatorValue.cs
+++ b/src/Marvin.Cache.Headers/Domain/ValidatorValue.cs
@@ -2,6 +2,7 @@
 // Any issues, requests: https://github.com/KevinDockx/HttpCacheHeaders
 
 using System;
+using System.Globalization;
 
 namespace Marvin.Cache.Headers
 {
@@ -14,6 +15,11 @@ namespace Marvin.Cache.Headers
         {
             ETag = eTag;
             LastModified = lastModified;
+        }
+
+        public override string ToString()
+        {
+            return $"ETag: {ETag} Last-Modified: {LastModified.ToString("r", CultureInfo.InvariantCulture)}";
         }
     }
 }

--- a/src/Marvin.Cache.Headers/Extensions/ServicesExtensions.cs
+++ b/src/Marvin.Cache.Headers/Extensions/ServicesExtensions.cs
@@ -27,10 +27,11 @@ namespace Microsoft.Extensions.DependencyInjection
                 null,
                 null,
                 null,
+                null,
                 null);
 
             return services;
-        } 
+        }
 
         /// <summary>
         /// Add HttpCacheHeaders services to the specified <see cref="IServiceCollection" />.
@@ -40,23 +41,26 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="validatorValueStoreFunc">Func to provide a custom <see cref="IValidatorValueStore" /></param>
         /// <param name="storeKeyGeneratorFunc">Func to provide a custom <see cref="IStoreKeyGenerator" /></param>
         /// <param name="eTagGeneratorFunc">Func to provide a custom <see cref="IETagGenerator" /></param>
+        /// <param name="validatorValueGenerator">Func to provide a custom <see cref="IValidatorValueGenerator" /></param>
         /// <returns></returns>
         public static IServiceCollection AddHttpCacheHeaders(
             this IServiceCollection services,
             Func<IServiceProvider, IDateParser> dateParserFunc = null,
             Func<IServiceProvider, IValidatorValueStore> validatorValueStoreFunc = null,
             Func<IServiceProvider, IStoreKeyGenerator> storeKeyGeneratorFunc = null,
-            Func<IServiceProvider, IETagGenerator> eTagGeneratorFunc = null)
-        { 
+            Func<IServiceProvider, IETagGenerator> eTagGeneratorFunc = null,
+            Func<IServiceProvider, IValidatorValueGenerator> validatorValueGenerator = null)
+        {
             AddModularParts(
                 services,
                 dateParserFunc,
                 validatorValueStoreFunc,
                 storeKeyGeneratorFunc,
-                eTagGeneratorFunc);
+                eTagGeneratorFunc,
+                validatorValueGenerator);
 
             return services;
-        } 
+        }
 
         /// <summary>
         /// Add HttpCacheHeaders services to the specified <see cref="IServiceCollection" />.
@@ -67,13 +71,15 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="validatorValueStoreFunc">Func to provide a custom <see cref="IValidatorValueStore" /></param>
         /// <param name="storeKeyGeneratorFunc">Func to provide a custom <see cref="IStoreKeyGenerator" /></param>
         /// <param name="eTagGeneratorFunc">Func to provide a custom <see cref="IETagGenerator" /></param>
+        /// <param name="validatorValueGenerator">Func to provide a custom <see cref="IValidatorValueGenerator" /></param>
         public static IServiceCollection AddHttpCacheHeaders(
             this IServiceCollection services,
             Action<ExpirationModelOptions> expirationModelOptionsAction,
             Func<IServiceProvider, IDateParser> dateParserFunc = null,
             Func<IServiceProvider, IValidatorValueStore> validatorValueStoreFunc = null,
             Func<IServiceProvider, IStoreKeyGenerator> storeKeyGeneratorFunc = null,
-            Func<IServiceProvider, IETagGenerator> eTagGeneratorFunc = null)
+            Func<IServiceProvider, IETagGenerator> eTagGeneratorFunc = null,
+            Func<IServiceProvider, IValidatorValueGenerator> validatorValueGenerator = null)
         {
             AddConfigureExpirationModelOptions(services, expirationModelOptionsAction);
 
@@ -82,7 +88,8 @@ namespace Microsoft.Extensions.DependencyInjection
                 dateParserFunc,
                 validatorValueStoreFunc,
                 storeKeyGeneratorFunc,
-                eTagGeneratorFunc);
+                eTagGeneratorFunc,
+                validatorValueGenerator);
 
             return services;
         }
@@ -96,13 +103,15 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="validatorValueStoreFunc">Func to provide a custom <see cref="IValidatorValueStore" /></param>
         /// <param name="storeKeyGeneratorFunc">Func to provide a custom <see cref="IStoreKeyGenerator" /></param>
         /// <param name="eTagGeneratorFunc">Func to provide a custom <see cref="IETagGenerator" /></param>
+        /// <param name="validatorValueGenerator">Func to provide a custom <see cref="IValidatorValueGenerator" /></param>
         public static IServiceCollection AddHttpCacheHeaders(
             this IServiceCollection services,
             Action<ValidationModelOptions> validationModelOptionsAction,
             Func<IServiceProvider, IDateParser> dateParserFunc = null,
             Func<IServiceProvider, IValidatorValueStore> validatorValueStoreFunc = null,
             Func<IServiceProvider, IStoreKeyGenerator> storeKeyGeneratorFunc = null,
-            Func<IServiceProvider, IETagGenerator> eTagGeneratorFunc = null)
+            Func<IServiceProvider, IETagGenerator> eTagGeneratorFunc = null,
+            Func<IServiceProvider, IValidatorValueGenerator> validatorValueGenerator = null)
         {
             AddConfigureValidationModelOptions(services, validationModelOptionsAction);
 
@@ -111,7 +120,8 @@ namespace Microsoft.Extensions.DependencyInjection
                 dateParserFunc,
                 validatorValueStoreFunc,
                 storeKeyGeneratorFunc,
-                eTagGeneratorFunc);
+                eTagGeneratorFunc,
+                validatorValueGenerator);
 
             return services;
         }
@@ -126,6 +136,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="validatorValueStoreFunc">Func to provide a custom <see cref="IValidatorValueStore" /></param>
         /// <param name="storeKeyGeneratorFunc">Func to provide a custom <see cref="IStoreKeyGenerator" /></param>
         /// <param name="eTagGeneratorFunc">Func to provide a custom <see cref="IETagGenerator" /></param>
+        /// <param name="validatorValueGenerator">Func to provide a custom <see cref="IValidatorValueGenerator" /></param>
         public static IServiceCollection AddHttpCacheHeaders(
             this IServiceCollection services,
             Action<ExpirationModelOptions> expirationModelOptionsAction,
@@ -133,7 +144,8 @@ namespace Microsoft.Extensions.DependencyInjection
             Func<IServiceProvider, IDateParser> dateParserFunc = null,
             Func<IServiceProvider, IValidatorValueStore> validatorValueStoreFunc = null,
             Func<IServiceProvider, IStoreKeyGenerator> storeKeyGeneratorFunc = null,
-            Func<IServiceProvider, IETagGenerator> eTagGeneratorFunc = null)
+            Func<IServiceProvider, IETagGenerator> eTagGeneratorFunc = null,
+            Func<IServiceProvider, IValidatorValueGenerator> validatorValueGenerator = null)
         {
             AddConfigureExpirationModelOptions(services, expirationModelOptionsAction);
             AddConfigureValidationModelOptions(services, validationModelOptionsAction);
@@ -143,7 +155,8 @@ namespace Microsoft.Extensions.DependencyInjection
                 dateParserFunc,
                 validatorValueStoreFunc,
                 storeKeyGeneratorFunc,
-                eTagGeneratorFunc);
+                eTagGeneratorFunc,
+                validatorValueGenerator);
 
             return services;
         }
@@ -153,14 +166,16 @@ namespace Microsoft.Extensions.DependencyInjection
             Func<IServiceProvider, IDateParser> dateParserFunc,
             Func<IServiceProvider, IValidatorValueStore> validatorValueStoreFunc,
             Func<IServiceProvider, IStoreKeyGenerator> storeKeyGeneratorFunc,
-            Func<IServiceProvider, IETagGenerator> eTagGeneratorFunc)
+            Func<IServiceProvider, IETagGenerator> eTagGeneratorFunc,
+            Func<IServiceProvider, IValidatorValueGenerator> validatorValueGenerator)
         {
             AddDateParser(services, dateParserFunc);
             AddValidatorValueStore(services, validatorValueStoreFunc);
             AddStoreKeyGenerator(services, storeKeyGeneratorFunc);
             AddETagGenerator(services, eTagGeneratorFunc);
+            AddValidatorValueGenerator(services, validatorValueGenerator);
         }
-        
+
         private static void AddDateParser(
             IServiceCollection services,
             Func<IServiceProvider, IDateParser> dateParserFunc)
@@ -227,6 +242,23 @@ namespace Microsoft.Extensions.DependencyInjection
             }
 
             services.Add(ServiceDescriptor.Singleton(typeof(IETagGenerator), eTagGeneratorFunc));
+        }
+
+        private static void AddValidatorValueGenerator(
+            IServiceCollection services,
+            Func<IServiceProvider, IValidatorValueGenerator> validatorValueGenerator)
+        {
+            if (services == null)
+            {
+                throw new ArgumentNullException(nameof(services));
+            }
+
+            if (validatorValueGenerator == null)
+            {
+                validatorValueGenerator = _ => new DefaultValidatorValueGenerator();
+            }
+
+            services.Add(ServiceDescriptor.Singleton(typeof(IValidatorValueGenerator), validatorValueGenerator));
         }
 
         private static void AddConfigureExpirationModelOptions(

--- a/src/Marvin.Cache.Headers/Interfaces/IETagGenerator.cs
+++ b/src/Marvin.Cache.Headers/Interfaces/IETagGenerator.cs
@@ -1,6 +1,7 @@
 ﻿// Any comments, input: @KevinDockx
 // Any issues, requests: https://github.com/KevinDockx/HttpCacheHeaders
 
+using Microsoft.AspNetCore.Http;
 using System.Threading.Tasks;
 
 namespace Marvin.Cache.Headers.Interfaces
@@ -10,6 +11,9 @@ namespace Marvin.Cache.Headers.Interfaces
     /// </summary>
     public interface IETagGenerator
     {
+        Task<ETag> GenerateETag(
+            HttpContext httpContext);
+
         Task<ETag> GenerateETag(
             StoreKey storeKey,
             string responseBodyContent);

--- a/src/Marvin.Cache.Headers/Interfaces/IETagGenerator.cs
+++ b/src/Marvin.Cache.Headers/Interfaces/IETagGenerator.cs
@@ -12,9 +12,6 @@ namespace Marvin.Cache.Headers.Interfaces
     public interface IETagGenerator
     {
         Task<ETag> GenerateETag(
-            HttpContext httpContext);
-
-        Task<ETag> GenerateETag(
             StoreKey storeKey,
             string responseBodyContent);
     }

--- a/src/Marvin.Cache.Headers/Interfaces/IValidatorValueGenerator.cs
+++ b/src/Marvin.Cache.Headers/Interfaces/IValidatorValueGenerator.cs
@@ -1,0 +1,19 @@
+﻿// Any comments, input: @KevinDockx
+// Any issues, requests: https://github.com/KevinDockx/HttpCacheHeaders
+
+using Microsoft.AspNetCore.Http;
+using System.Threading.Tasks;
+
+namespace Marvin.Cache.Headers.Interfaces
+{
+    /// <summary>
+    /// Contract for an Validator Value Generator, used to generate the unique weak or strong E-Tags for cache items and Last Modified Time.
+    /// </summary>
+    public interface IValidatorValueGenerator
+    {
+        Task<ValidatorValue> Generate(
+            StoreKey storeKey,
+            HttpContext httpContext,
+            IETagGenerator eTagGenerator = null);
+    }
+}

--- a/src/Marvin.Cache.Headers/Marvin.Cache.Headers.csproj
+++ b/src/Marvin.Cache.Headers/Marvin.Cache.Headers.csproj
@@ -9,8 +9,9 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <Version>2.0.0</Version>
+    <Version>3.1.0-beta001</Version>
     <Description>ASP.NET Core middleware that adds HttpCache headers to responses (Cache-Control, Expires, ETag, Last-Modified), and implements cache expiration &amp; validation models.</Description>
+    <FileVersion>3.1.0.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Marvin.Cache.Headers.Test/DefaultConfigurationFacts.cs
+++ b/test/Marvin.Cache.Headers.Test/DefaultConfigurationFacts.cs
@@ -105,6 +105,10 @@ namespace Marvin.Cache.Headers.Test
                 Assert.Equal(
                     response1.Headers.GetValues(HeaderNames.ETag).First(),
                     response2.Headers.GetValues(HeaderNames.ETag).First());
+
+                Assert.Equal(
+                    lastmodified,
+                    response2.Content.Headers.LastModified);
             }
         }
     }

--- a/test/Marvin.Cache.Headers.Test/Domain/ETagFacts.cs
+++ b/test/Marvin.Cache.Headers.Test/Domain/ETagFacts.cs
@@ -1,0 +1,64 @@
+﻿// Any comments, input: @KevinDockx
+// Any issues, requests: https://github.com/KevinDockx/HttpCacheHeaders
+
+using Xunit;
+
+namespace Marvin.Cache.Headers.Test.Domain
+{
+    public class ETagFacts
+    {
+        [Fact]
+        public void Correctly_Build_Strong_ETag()
+        {
+            var eTag = new ETag("\"THISISSTRONG\"");
+
+            Assert.Equal("THISISSTRONG", eTag.Value);
+            Assert.Equal(ETagType.Strong, eTag.ETagType);
+        }
+
+        [Fact]
+        public void Correctly_Build_Weak_ETag()
+        {
+            var eTag = new ETag("W\"THISISWEAK\"");
+
+            Assert.Equal("THISISWEAK", eTag.Value);
+            Assert.Equal(ETagType.Weak, eTag.ETagType);
+        }
+
+        [Fact]
+        public void Correctly_Build_Unknown_NoDefault_ETag()
+        {
+            var eTag = new ETag("THISISUNKNOWN");
+
+            Assert.Equal("THISISUNKNOWN", eTag.Value);
+            Assert.Equal(ETagType.Weak, eTag.ETagType);
+        }
+
+        [Fact]
+        public void Correctly_Build_Unknown_WithDefault_ETag()
+        {
+            var eTag = new ETag("THISISUNKNOWN", ETagType.Strong);
+
+            Assert.Equal("THISISUNKNOWN", eTag.Value);
+            Assert.Equal(ETagType.Strong, eTag.ETagType);
+        }
+
+        [Fact]
+        public void Correctly_Build_NullValue_ETag()
+        {
+            var eTag = new ETag(null);
+
+            Assert.Null(eTag.Value);
+            Assert.Equal(ETagType.Weak, eTag.ETagType);
+        }
+
+        [Fact]
+        public void Correctly_Build_NoValue_ETag()
+        {
+            var eTag = new ETag(" ");
+
+            Assert.Null(eTag.Value);
+            Assert.Equal(ETagType.Weak, eTag.ETagType);
+        }
+    }
+}


### PR DESCRIPTION
Enclosed please find a change that allows one to use the HttpContext to generate\acquire and ETag before going through the effort of building an Etag from the response body. Since I have a data source, CosmosDb, already proving me an Etag for a resource, I wanted a system to provide that ETag to this software. This also allows me to pass along this ETag to CosmosDb Create, Upsert, Replace, and Remove methods for it to use for another concurrency check. 

The new interface method I added to IETagGenerator allows users of this package to provide custom logic for generating an ETag from the HttpContext. The default solution is to look for httpContext.Items["ETag"] and use that as the ETag if it exists. If it does not, the software will use the method that you implemented in this package. If th Etag is acquired from the HttpContext, the software will bypass prepping the response body for ETag generation.

I also added a new constructor to the ETag class that takes in a string value and determines if the value is weak or strong. If the method cannot determine the strength of the value, the default value, which is a parameter, is applied.

