### PR TITLE
Hotfixes/issue 82 ignore if modified since when if none match is present

### DIFF
--- a/test/Marvin.Cache.Headers.Test/DefaultConfigurationFacts.cs
+++ b/test/Marvin.Cache.Headers.Test/DefaultConfigurationFacts.cs
@@ -1,13 +1,13 @@
 ﻿// Any comments, input: @KevinDockx
 // Any issues, requests: https://github.com/KevinDockx/HttpCacheHeaders
 
-using System.Linq;
-using System.Net;
-using System.Threading.Tasks;
 using Marvin.Cache.Headers.Test.TestStartups;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Net.Http.Headers;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
 using Xunit;
 using EntityTagHeaderValue = System.Net.Http.Headers.EntityTagHeaderValue;
 
@@ -105,6 +105,74 @@ namespace Marvin.Cache.Headers.Test
                 Assert.Equal(
                     response1.Headers.GetValues(HeaderNames.ETag).First(),
                     response2.Headers.GetValues(HeaderNames.ETag).First());
+            }
+        }
+
+        [Fact]
+        public async Task Returns_304_NotModified_When_Request_Has_Matching_Etag_And_No_IfModifiedSince()
+        {
+            using (var client = _server.CreateClient())
+            {
+                var response1 = await client.GetAsync("/");
+                var etag = response1.Headers.GetValues(HeaderNames.ETag).First();
+
+                client.DefaultRequestHeaders.IfNoneMatch.Add(new EntityTagHeaderValue(etag, false));
+                var response2 = await client.GetAsync("/");
+
+                Assert.True(response1.IsSuccessStatusCode);
+                Assert.True(response2.StatusCode == HttpStatusCode.NotModified);
+            }
+        }
+
+        [Fact]
+        public async Task Returns_304_NotModified_When_Request_HasValid_IfModifiedSince_AndNo_Etag()
+        {
+            using (var client = _server.CreateClient())
+            {
+                var response1 = await client.GetAsync("/");
+                var lastmodified = response1.Content.Headers.LastModified;
+
+                client.DefaultRequestHeaders.IfModifiedSince = lastmodified;
+                var response2 = await client.GetAsync("/");
+
+                Assert.True(response1.IsSuccessStatusCode);
+                Assert.True(response2.StatusCode == HttpStatusCode.NotModified);
+            }
+        }
+
+        [Fact]
+        public async Task IfModifiedSince_OnRequest_IsIgnored_When_RequestContains_Valid_IfNoneMatch_Header()
+        {
+            using (var client = _server.CreateClient())
+            {
+                var response1 = await client.GetAsync("/");
+                var lastmodified = response1.Content.Headers.LastModified;
+                var etag = response1.Headers.GetValues(HeaderNames.ETag).First();
+
+                var expiredLastModified = lastmodified.Value.AddMilliseconds(-600000);
+                client.DefaultRequestHeaders.IfNoneMatch.Add(new EntityTagHeaderValue(etag, false));
+                client.DefaultRequestHeaders.IfModifiedSince = expiredLastModified;
+                var response2 = await client.GetAsync("/");
+
+                Assert.True(response1.IsSuccessStatusCode);
+                Assert.True(response2.StatusCode == HttpStatusCode.NotModified);
+            }
+        }
+
+        [Fact]
+        public async Task Returns_200_Ok_When_Request_HasValid_IfModifiedSince_But_Invalid_Etag()
+        {
+            using (var client = _server.CreateClient())
+            {
+                var response1 = await client.GetAsync("/");
+                var lastmodified = response1.Content.Headers.LastModified;
+
+                client.DefaultRequestHeaders.IfNoneMatch.Add(new EntityTagHeaderValue("\"invalid-etag\"", false));
+                client.DefaultRequestHeaders.IfModifiedSince = lastmodified;
+                var response2 = await client.GetAsync("/");
+
+                Assert.True(response1.IsSuccessStatusCode);
+                Assert.True(response2.StatusCode == HttpStatusCode.OK);
             }
         }
     }

--- a/test/Marvin.Cache.Headers.Test/DefaultConfigurationFacts.cs
+++ b/test/Marvin.Cache.Headers.Test/DefaultConfigurationFacts.cs
@@ -86,7 +86,7 @@ namespace Marvin.Cache.Headers.Test
         [InlineData(500)]
         [InlineData(1000)]
         [InlineData(1500)]
-        public async Task Return_302_When_Request_Is_Cached(int delayInMs)
+        public async Task Return_304_When_Request_Is_Cached(int delayInMs)
         {
             using (var client = _server.CreateClient())
             {


### PR DESCRIPTION
Updated the middleware so that If-Modified-Since is always ignored when an If-None-Match header is present in a conditional GET or HEAD request. Resolves issue [https://github.com/KevinDockx/HttpCacheHeaders/issues/82](https://github.com/KevinDockx/HttpCacheHeaders/issues/82)