### PR TITLE
Allow caching to be ignored globally

### DIFF
--- a/src/Marvin.Cache.Headers/Domain/HttpCacheHeadersMiddlewareOptions.cs
+++ b/src/Marvin.Cache.Headers/Domain/HttpCacheHeadersMiddlewareOptions.cs
@@ -1,0 +1,16 @@
+﻿// Any comments, input: @KevinDockx
+// Any issues, requests: https://github.com/KevinDockx/HttpCacheHeaders
+
+namespace Marvin.Cache.Headers
+{
+    /// <summary>
+    /// Options that have to do with the HttpCacheHeadersMiddleware, mainly to do with ignoring caching globally.
+    /// </summary>
+    public class HttpCacheHeadersMiddlewareOptions
+    {
+        /// <summary>
+        /// Ignore caching on a global level, defaults to false.
+        /// </summary>
+        public bool IgnoreCaching { get; set; } = false;
+    }
+    }

--- a/src/Marvin.Cache.Headers/HttpCacheHeadersMiddleware.cs
+++ b/src/Marvin.Cache.Headers/HttpCacheHeadersMiddleware.cs
@@ -31,6 +31,7 @@ namespace Marvin.Cache.Headers
         private readonly IStoreKeyGenerator _storeKeyGenerator;
         private readonly IETagGenerator _eTagGenerator;
         private readonly ILastModifiedInjector _lastModifiedInjector;
+        private readonly IOptions<HttpCacheHeadersMiddlewareOptions> _httpCacheHeadersMiddlewareOptions;
         private readonly ValidationModelOptions _validationModelOptions;
         private readonly ExpirationModelOptions _expirationModelOptions;
 
@@ -44,12 +45,18 @@ namespace Marvin.Cache.Headers
             IStoreKeyGenerator storeKeyGenerator,
             IETagGenerator eTagGenerator,
             ILastModifiedInjector lastModifiedInjector,
-            IOptions<ExpirationModelOptions> expirationModelOptions,
+            IOptions<HttpCacheHeadersMiddlewareOptions> httpCacheHeadersMiddlewareOptions, 
+            IOptions<ExpirationModelOptions> expirationModelOptions, 
             IOptions<ValidationModelOptions> validationModelOptions)
         {
             if (loggerFactory == null)
             {
                 throw new ArgumentNullException(nameof(loggerFactory));
+            }
+
+            if (httpCacheHeadersMiddlewareOptions ==null)
+            {
+                throw new ArgumentNullException(nameof(httpCacheHeadersMiddlewareOptions));
             }
 
             if (validationModelOptions == null)
@@ -69,7 +76,7 @@ namespace Marvin.Cache.Headers
             _storeKeyGenerator = storeKeyGenerator ?? throw new ArgumentNullException(nameof(storeKeyGenerator));
             _eTagGenerator = eTagGenerator ?? throw new ArgumentNullException(nameof(eTagGenerator));
             _lastModifiedInjector = lastModifiedInjector ?? throw new ArgumentNullException(nameof(lastModifiedInjector));
-
+            _httpCacheHeadersMiddlewareOptions = httpCacheHeadersMiddlewareOptions;
             _expirationModelOptions = expirationModelOptions.Value;
             _validationModelOptions = validationModelOptions.Value;
 

--- a/src/Marvin.Cache.Headers/HttpCacheHeadersMiddleware.cs
+++ b/src/Marvin.Cache.Headers/HttpCacheHeadersMiddleware.cs
@@ -31,7 +31,7 @@ namespace Marvin.Cache.Headers
         private readonly IStoreKeyGenerator _storeKeyGenerator;
         private readonly IETagGenerator _eTagGenerator;
         private readonly ILastModifiedInjector _lastModifiedInjector;
-        private readonly IOptions<HttpCacheHeadersMiddlewareOptions> _httpCacheHeadersMiddlewareOptions;
+        private readonly HttpCacheHeadersMiddlewareOptions _httpCacheHeadersMiddlewareOptions;
         private readonly ValidationModelOptions _validationModelOptions;
         private readonly ExpirationModelOptions _expirationModelOptions;
 
@@ -76,7 +76,7 @@ namespace Marvin.Cache.Headers
             _storeKeyGenerator = storeKeyGenerator ?? throw new ArgumentNullException(nameof(storeKeyGenerator));
             _eTagGenerator = eTagGenerator ?? throw new ArgumentNullException(nameof(eTagGenerator));
             _lastModifiedInjector = lastModifiedInjector ?? throw new ArgumentNullException(nameof(lastModifiedInjector));
-            _httpCacheHeadersMiddlewareOptions = httpCacheHeadersMiddlewareOptions;
+            _httpCacheHeadersMiddlewareOptions = httpCacheHeadersMiddlewareOptions.Value;
             _expirationModelOptions = expirationModelOptions.Value;
             _validationModelOptions = validationModelOptions.Value;
 

--- a/src/Marvin.Cache.Headers/Marvin.Cache.Headers.csproj
+++ b/src/Marvin.Cache.Headers/Marvin.Cache.Headers.csproj
@@ -8,7 +8,7 @@
 		<GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
 		<GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
 		<GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-		<Version>6.1.0</Version>
+		<Version>7.0.0</Version>
 		<Description>ASP.NET Core middleware that adds HttpCache headers to responses (Cache-Control, Expires, ETag, Last-Modified), and implements cache expiration &amp; validation models.</Description>
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 		<Authors>KevinDockx, Kevin Dockx</Authors>


### PR DESCRIPTION
This PR provides a way to allow caching to be ignored globally using a new options type and fixes issues #109.