### PR TITLE
Disable caching for specific status codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,21 +32,30 @@ app.UseEndpoints(...);
 
 # Configuring Options
 
-The middleware allows customization of how headers are generated.  The AddHttpCacheHeaders() method has overloads for configuring options related to expiration, validation or both.  
+The middleware allows customization of how headers are generated. The AddHttpCacheHeaders() method has parameters for configuring options related to expiration, validation and middleware.  
 
-For example, this code will set the max-age directive to 600 seconds, and will add the must-revalidate directive.
+For example, this code will set the max-age directive to 600 seconds, add the must-revalidate directive and ignore caching for all responses with status code 500.
 
 ````csharp
 services.AddHttpCacheHeaders(
-    (expirationModelOptions) =>
+    expirationModelOptions =>
     {
         expirationModelOptions.MaxAge = 600;
     },
-    (validationModelOptions) =>
+    validationModelOptions =>
     {
         validationModelOptions.MustRevalidate = true;
+    },
+    middlewareOptions => 
+    {
+        middlewareOptions.IgnoreStatusCodes = new[] { 500 };
     });
 ````
+
+There are some predefined collections with status codes you can use when you want to ignore:
+- all server errors `HttpStatusCodes.ServerErrors`
+- all client errors `HttpStatusCodes.ClientErrors`
+- all errors `HttpStatusCodes.AllErrors`
 
 # Action (Resource) and Controller-level Header Configuration
 
@@ -247,4 +256,3 @@ public interface IStoreKeyAccessor
     Task<IEnumerable<StoreKey>> FindByCurrentResourcePath();
 }
 ````
-

--- a/src/Marvin.Cache.Headers/Domain/HttpCacheHeadersMiddlewareOptions.cs
+++ b/src/Marvin.Cache.Headers/Domain/HttpCacheHeadersMiddlewareOptions.cs
@@ -1,16 +1,28 @@
 ﻿// Any comments, input: @KevinDockx
 // Any issues, requests: https://github.com/KevinDockx/HttpCacheHeaders
 
+using System.Collections.Generic;
+using System.Linq;
+
 namespace Marvin.Cache.Headers
 {
     /// <summary>
-    /// Options that have to do with the HttpCacheHeadersMiddleware, mainly to do with ignoring caching globally.
+    /// Options that have to do with the HttpCacheHeadersMiddleware, mainly with ignoring caching globally.
     /// </summary>
     public class HttpCacheHeadersMiddlewareOptions
     {
         /// <summary>
-        /// Ignore caching on a global level, defaults to false.
+        /// Ignore caching on a global level
+        ///
+        /// Defaults to false.
         /// </summary>
         public bool IgnoreCaching { get; set; } = false;
+        
+        /// <summary>
+        /// Ignore caching on responses with specific status codes.
+        ///
+        /// Defaults to none.
+        /// </summary>
+        public IEnumerable<int> IgnoredStatusCodes { get; set; } = Enumerable.Empty<int>();
     }
-    }
+}

--- a/src/Marvin.Cache.Headers/Domain/MiddlewareOptions.cs
+++ b/src/Marvin.Cache.Headers/Domain/MiddlewareOptions.cs
@@ -9,7 +9,7 @@ namespace Marvin.Cache.Headers
     /// <summary>
     /// Options that have to do with the HttpCacheHeadersMiddleware, mainly with ignoring caching globally.
     /// </summary>
-    public class HttpCacheHeadersMiddlewareOptions
+    public class MiddlewareOptions
     {
         /// <summary>
         /// Ignore caching on a global level

--- a/src/Marvin.Cache.Headers/Extensions/ServicesExtensions.cs
+++ b/src/Marvin.Cache.Headers/Extensions/ServicesExtensions.cs
@@ -1,12 +1,12 @@
 ﻿// Any comments, input: @KevinDockx
 // Any issues, requests: https://github.com/KevinDockx/HttpCacheHeaders
 
+using System;
 using Marvin.Cache.Headers;
 using Marvin.Cache.Headers.Interfaces;
 using Marvin.Cache.Headers.Stores;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection.Extensions;
-using System;
 
 namespace Microsoft.Extensions.DependencyInjection
 {
@@ -15,119 +15,6 @@ namespace Microsoft.Extensions.DependencyInjection
     /// </summary>
     public static class ServicesExtensions
     {
-
-        /// <summary>
-        /// Add HttpCacheHeaders services to the specified <see cref="IServiceCollection" />.
-        /// </summary>
-        /// <param name="services">The <see cref="IServiceCollection" /> to add services to.</param>
-        /// <returns>An <see cref="IServiceCollection" />.</returns>
-        public static IServiceCollection AddHttpCacheHeaders(
-          this IServiceCollection services)
-        {
-            AddModularParts(
-                services,
-                null,
-                null,
-                null,
-                null,
-                null);
-
-            return services;
-        }
-
-        /// <summary>
-        /// Add HttpCacheHeaders services to the specified <see cref="IServiceCollection" />.
-        /// </summary>
-        /// <param name="services">The <see cref="IServiceCollection" /> to add services to.</param>
-        /// <param name="dateParserFunc">Func to provide a custom <see cref="IDateParser" /></param>
-        /// <param name="validatorValueStoreFunc">Func to provide a custom <see cref="IValidatorValueStore" /></param>
-        /// <param name="storeKeyGeneratorFunc">Func to provide a custom <see cref="IStoreKeyGenerator" /></param>
-        /// <param name="eTagGeneratorFunc">Func to provide a custom <see cref="IETagGenerator" /></param>
-        /// <param name="lastModifiedInjectorFunc">Func to provide a custom <see cref="ILastModifiedInjector" /></param>
-        /// <returns></returns>
-        public static IServiceCollection AddHttpCacheHeaders(
-            this IServiceCollection services,
-            Func<IServiceProvider, IDateParser> dateParserFunc = null,
-            Func<IServiceProvider, IValidatorValueStore> validatorValueStoreFunc = null,
-            Func<IServiceProvider, IStoreKeyGenerator> storeKeyGeneratorFunc = null,
-            Func<IServiceProvider, IETagGenerator> eTagGeneratorFunc = null,
-            Func<IServiceProvider, ILastModifiedInjector> lastModifiedInjectorFunc = null)
-        { 
-            AddModularParts(
-                services,
-                dateParserFunc,
-                validatorValueStoreFunc,
-                storeKeyGeneratorFunc,
-                eTagGeneratorFunc,
-                lastModifiedInjectorFunc);
-
-            return services;
-        }
-
-        /// <summary>
-        /// Add HttpCacheHeaders services to the specified <see cref="IServiceCollection" />.
-        /// </summary>
-        /// <param name="services">The <see cref="IServiceCollection" /> to add services to.</param>
-        /// <param name="expirationModelOptionsAction">Action to provide custom <see cref="ExpirationModelOptions" /></param>
-        /// <param name="dateParserFunc">Func to provide a custom <see cref="IDateParser" /></param>
-        /// <param name="validatorValueStoreFunc">Func to provide a custom <see cref="IValidatorValueStore" /></param>
-        /// <param name="storeKeyGeneratorFunc">Func to provide a custom <see cref="IStoreKeyGenerator" /></param>
-        /// <param name="eTagGeneratorFunc">Func to provide a custom <see cref="IETagGenerator" /></param>
-        /// <param name="lastModifiedInjectorFunc">Func to provide a custom <see cref="ILastModifiedInjector" /></param>
-        public static IServiceCollection AddHttpCacheHeaders(
-            this IServiceCollection services,
-            Action<ExpirationModelOptions> expirationModelOptionsAction,
-            Func<IServiceProvider, IDateParser> dateParserFunc = null,
-            Func<IServiceProvider, IValidatorValueStore> validatorValueStoreFunc = null,
-            Func<IServiceProvider, IStoreKeyGenerator> storeKeyGeneratorFunc = null,
-            Func<IServiceProvider, IETagGenerator> eTagGeneratorFunc = null,
-            Func<IServiceProvider, ILastModifiedInjector> lastModifiedInjectorFunc = null)
-        {
-            AddConfigureExpirationModelOptions(services, expirationModelOptionsAction);
-
-            AddModularParts(
-                services,
-                dateParserFunc,
-                validatorValueStoreFunc,
-                storeKeyGeneratorFunc,
-                eTagGeneratorFunc,
-                lastModifiedInjectorFunc);
-
-            return services;
-        }
-
-        /// <summary>
-        /// Add HttpCacheHeaders services to the specified <see cref="IServiceCollection" />.
-        /// </summary>
-        /// <param name="services">The <see cref="IServiceCollection" /> to add services to.</param>
-        /// <param name="validationModelOptionsAction">Action to provide custom <see cref="ValidationModelOptions" /></param>
-        /// <param name="dateParserFunc">Func to provide a custom <see cref="IDateParser" /></param>
-        /// <param name="validatorValueStoreFunc">Func to provide a custom <see cref="IValidatorValueStore" /></param>
-        /// <param name="storeKeyGeneratorFunc">Func to provide a custom <see cref="IStoreKeyGenerator" /></param>
-        /// <param name="eTagGeneratorFunc">Func to provide a custom <see cref="IETagGenerator" /></param>
-        /// <param name="lastModifiedInjectorFunc">Func to provide a custom <see cref="ILastModifiedInjector" /></param>
-        public static IServiceCollection AddHttpCacheHeaders(
-            this IServiceCollection services,
-            Action<ValidationModelOptions> validationModelOptionsAction,
-            Func<IServiceProvider, IDateParser> dateParserFunc = null,
-            Func<IServiceProvider, IValidatorValueStore> validatorValueStoreFunc = null,
-            Func<IServiceProvider, IStoreKeyGenerator> storeKeyGeneratorFunc = null,
-            Func<IServiceProvider, IETagGenerator> eTagGeneratorFunc = null,
-            Func<IServiceProvider, ILastModifiedInjector> lastModifiedInjectorFunc = null)
-        {
-            AddConfigureValidationModelOptions(services, validationModelOptionsAction);
-
-            AddModularParts(
-                services,
-                dateParserFunc,
-                validatorValueStoreFunc,
-                storeKeyGeneratorFunc,
-                eTagGeneratorFunc,
-                lastModifiedInjectorFunc);
-
-            return services;
-        }
-
         /// <summary>
         /// Add HttpCacheHeaders services to the specified <see cref="IServiceCollection" />.
         /// </summary>
@@ -141,16 +28,21 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="lastModifiedInjectorFunc">Func to provide a custom <see cref="ILastModifiedInjector" /></param>
         public static IServiceCollection AddHttpCacheHeaders(
             this IServiceCollection services,
-            Action<ExpirationModelOptions> expirationModelOptionsAction,
-            Action<ValidationModelOptions> validationModelOptionsAction,
+            Action<ExpirationModelOptions> expirationModelOptionsAction = null,
+            Action<ValidationModelOptions> validationModelOptionsAction = null,
+            Action<HttpCacheHeadersMiddlewareOptions> middlewareOptionsAction = null,
             Func<IServiceProvider, IDateParser> dateParserFunc = null,
             Func<IServiceProvider, IValidatorValueStore> validatorValueStoreFunc = null,
             Func<IServiceProvider, IStoreKeyGenerator> storeKeyGeneratorFunc = null,
             Func<IServiceProvider, IETagGenerator> eTagGeneratorFunc = null,
             Func<IServiceProvider, ILastModifiedInjector> lastModifiedInjectorFunc = null)
         {
-            AddConfigureExpirationModelOptions(services, expirationModelOptionsAction);
-            AddConfigureValidationModelOptions(services, validationModelOptionsAction);
+            if(expirationModelOptionsAction != null)
+                AddConfigureExpirationModelOptions(services, expirationModelOptionsAction);
+            if(validationModelOptionsAction != null)
+                AddConfigureValidationModelOptions(services, validationModelOptionsAction);
+            if(middlewareOptionsAction != null)
+                AddConfigureMiddlewareOptions(services, middlewareOptionsAction);
 
             AddModularParts(
                 services,
@@ -269,6 +161,23 @@ namespace Microsoft.Extensions.DependencyInjection
             }
 
             services.Add(ServiceDescriptor.Singleton(typeof(IETagGenerator), eTagGeneratorFunc));
+        }
+        
+        private static void AddConfigureMiddlewareOptions(
+            IServiceCollection services,
+            Action<HttpCacheHeadersMiddlewareOptions> configureExpirationModelOptions)
+        {
+            if (services == null)
+            {
+                throw new ArgumentNullException(nameof(services));
+            }
+
+            if (configureExpirationModelOptions == null)
+            {
+                throw new ArgumentNullException(nameof(configureExpirationModelOptions));
+            }
+
+            services.Configure(configureExpirationModelOptions);
         }
 
         private static void AddConfigureExpirationModelOptions(

--- a/src/Marvin.Cache.Headers/Extensions/ServicesExtensions.cs
+++ b/src/Marvin.Cache.Headers/Extensions/ServicesExtensions.cs
@@ -21,6 +21,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="services">The <see cref="IServiceCollection" /> to add services to.</param>
         /// <param name="expirationModelOptionsAction">Action to provide custom <see cref="ExpirationModelOptions" /></param>
         /// <param name="validationModelOptionsAction">Action to provide custom <see cref="ValidationModelOptions" /></param>
+        /// <param name="middlewareOptionsAction">Action to provide custom <see cref="MiddlewareOptions" /></param>
         /// <param name="dateParserFunc">Func to provide a custom <see cref="IDateParser" /></param>
         /// <param name="validatorValueStoreFunc">Func to provide a custom <see cref="IValidatorValueStore" /></param>
         /// <param name="storeKeyGeneratorFunc">Func to provide a custom <see cref="IStoreKeyGenerator" /></param>

--- a/src/Marvin.Cache.Headers/Extensions/ServicesExtensions.cs
+++ b/src/Marvin.Cache.Headers/Extensions/ServicesExtensions.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Extensions.DependencyInjection
             this IServiceCollection services,
             Action<ExpirationModelOptions> expirationModelOptionsAction = null,
             Action<ValidationModelOptions> validationModelOptionsAction = null,
-            Action<HttpCacheHeadersMiddlewareOptions> middlewareOptionsAction = null,
+            Action<MiddlewareOptions> middlewareOptionsAction = null,
             Func<IServiceProvider, IDateParser> dateParserFunc = null,
             Func<IServiceProvider, IValidatorValueStore> validatorValueStoreFunc = null,
             Func<IServiceProvider, IStoreKeyGenerator> storeKeyGeneratorFunc = null,
@@ -165,7 +165,7 @@ namespace Microsoft.Extensions.DependencyInjection
         
         private static void AddConfigureMiddlewareOptions(
             IServiceCollection services,
-            Action<HttpCacheHeadersMiddlewareOptions> configureExpirationModelOptions)
+            Action<MiddlewareOptions> configureExpirationModelOptions)
         {
             if (services == null)
             {

--- a/src/Marvin.Cache.Headers/HttpCacheHeadersMiddleware.cs
+++ b/src/Marvin.Cache.Headers/HttpCacheHeadersMiddleware.cs
@@ -29,7 +29,7 @@ namespace Marvin.Cache.Headers
         private readonly IStoreKeyGenerator _storeKeyGenerator;
         private readonly IETagGenerator _eTagGenerator;
         private readonly ILastModifiedInjector _lastModifiedInjector;
-        private readonly HttpCacheHeadersMiddlewareOptions _httpCacheHeadersMiddlewareOptions;
+        private readonly MiddlewareOptions _middlewareOptions;
         private readonly ValidationModelOptions _validationModelOptions;
         private readonly ExpirationModelOptions _expirationModelOptions;
 
@@ -43,7 +43,7 @@ namespace Marvin.Cache.Headers
             IStoreKeyGenerator storeKeyGenerator,
             IETagGenerator eTagGenerator,
             ILastModifiedInjector lastModifiedInjector,
-            IOptions<HttpCacheHeadersMiddlewareOptions> httpCacheHeadersMiddlewareOptions, 
+            IOptions<MiddlewareOptions> httpCacheHeadersMiddlewareOptions, 
             IOptions<ExpirationModelOptions> expirationModelOptions, 
             IOptions<ValidationModelOptions> validationModelOptions)
         {
@@ -74,7 +74,7 @@ namespace Marvin.Cache.Headers
             _storeKeyGenerator = storeKeyGenerator ?? throw new ArgumentNullException(nameof(storeKeyGenerator));
             _eTagGenerator = eTagGenerator ?? throw new ArgumentNullException(nameof(eTagGenerator));
             _lastModifiedInjector = lastModifiedInjector ?? throw new ArgumentNullException(nameof(lastModifiedInjector));
-            _httpCacheHeadersMiddlewareOptions = httpCacheHeadersMiddlewareOptions.Value;
+            _middlewareOptions = httpCacheHeadersMiddlewareOptions.Value;
             _expirationModelOptions = expirationModelOptions.Value;
             _validationModelOptions = validationModelOptions.Value;
 
@@ -123,7 +123,7 @@ namespace Marvin.Cache.Headers
                 return true;
             }
 
-            if (_httpCacheHeadersMiddlewareOptions.IgnoreCaching)
+            if (_middlewareOptions.IgnoreCaching)
             {
                 return true;
             }
@@ -262,7 +262,7 @@ namespace Marvin.Cache.Headers
 
         private bool ShouldResponseBeIgnored(HttpContext httpContext)
         {
-            var isResponseStatusCodeIgnored = _httpCacheHeadersMiddlewareOptions.IgnoredStatusCodes.Contains(httpContext.Response.StatusCode);
+            var isResponseStatusCodeIgnored = _middlewareOptions.IgnoredStatusCodes.Contains(httpContext.Response.StatusCode);
 
             if (isResponseStatusCodeIgnored)
                 return true;

--- a/src/Marvin.Cache.Headers/HttpCacheHeadersMiddleware.cs
+++ b/src/Marvin.Cache.Headers/HttpCacheHeadersMiddleware.cs
@@ -43,7 +43,7 @@ namespace Marvin.Cache.Headers
             IStoreKeyGenerator storeKeyGenerator,
             IETagGenerator eTagGenerator,
             ILastModifiedInjector lastModifiedInjector,
-            IOptions<MiddlewareOptions> httpCacheHeadersMiddlewareOptions, 
+            IOptions<MiddlewareOptions> middlewareOptions,
             IOptions<ExpirationModelOptions> expirationModelOptions, 
             IOptions<ValidationModelOptions> validationModelOptions)
         {
@@ -52,9 +52,9 @@ namespace Marvin.Cache.Headers
                 throw new ArgumentNullException(nameof(loggerFactory));
             }
 
-            if (httpCacheHeadersMiddlewareOptions ==null)
+            if (middlewareOptions ==null)
             {
-                throw new ArgumentNullException(nameof(httpCacheHeadersMiddlewareOptions));
+                throw new ArgumentNullException(nameof(middlewareOptions));
             }
 
             if (validationModelOptions == null)
@@ -74,7 +74,7 @@ namespace Marvin.Cache.Headers
             _storeKeyGenerator = storeKeyGenerator ?? throw new ArgumentNullException(nameof(storeKeyGenerator));
             _eTagGenerator = eTagGenerator ?? throw new ArgumentNullException(nameof(eTagGenerator));
             _lastModifiedInjector = lastModifiedInjector ?? throw new ArgumentNullException(nameof(lastModifiedInjector));
-            _middlewareOptions = httpCacheHeadersMiddlewareOptions.Value;
+            _middlewareOptions = middlewareOptions.Value;
             _expirationModelOptions = expirationModelOptions.Value;
             _validationModelOptions = validationModelOptions.Value;
 

--- a/src/Marvin.Cache.Headers/Utils/HttpStatusCodes.cs
+++ b/src/Marvin.Cache.Headers/Utils/HttpStatusCodes.cs
@@ -1,0 +1,28 @@
+using System.Collections.Generic;
+using System.Linq;
+
+// Used list on https://en.wikipedia.org/wiki/List_of_HTTP_status_codes
+
+namespace Marvin.Cache.Headers.Utils
+{
+    /// <summary>
+    /// Contains predefined list of status codes.
+    /// </summary>
+    public static class HttpStatusCodes
+    {
+        /// <summary>
+        /// Contains all status codes for client errors in the 4xx range.
+        /// </summary>
+        public static readonly IEnumerable<int> ClientErrors = new[] { 400, 401, 402, 403, 404, 405, 406, 407, 408, 409, 410, 411, 412, 413, 414, 415, 416, 417, 418, 419, 420, 421, 422, 423, 424, 425, 426, 428, 429, 430, 431, 440, 449, 450, 451, 498, 499 };
+
+        /// <summary>
+        /// Contains all status codes for server errors in the 5xx range.
+        /// </summary>
+        public static readonly IEnumerable<int> ServerErrors = new[] { 500, 501, 502, 503, 504, 505, 506, 507, 508, 509, 510, 511, 529, 530, 598, 599 };
+
+        /// <summary>
+        /// Contains all error status codes in the 4xx and 5xx range.
+        /// </summary>
+        public static readonly IEnumerable<int> AllErrors = ClientErrors.Concat(ServerErrors);
+    }
+}

--- a/test/Marvin.Cache.Headers.Test/Extensions/ServiceExtensionFacts.cs
+++ b/test/Marvin.Cache.Headers.Test/Extensions/ServiceExtensionFacts.cs
@@ -58,7 +58,7 @@ namespace Marvin.Cache.Headers.Test.Extensions
                       .ConfigureServices(service =>
                       {
                           service.AddControllers();
-                          service.AddHttpCacheHeaders(options => options.NoCache = true);
+                          service.AddHttpCacheHeaders(validationModelOptionsAction: options => options.NoCache = true);
                       });  
 
             var testServer = new TestServer(hostBuilder);
@@ -118,7 +118,7 @@ namespace Marvin.Cache.Headers.Test.Extensions
             IServiceCollection serviceCollection = null;
 
             Assert.Throws<ArgumentNullException>(
-                () => serviceCollection.AddHttpCacheHeaders(options => options.NoCache = true));
+                () => serviceCollection.AddHttpCacheHeaders(validationModelOptionsAction: options => options.NoCache = true));
         }
 
         [Fact]

--- a/test/Marvin.Cache.Headers.Test/IgnoreCachingFacts.cs
+++ b/test/Marvin.Cache.Headers.Test/IgnoreCachingFacts.cs
@@ -2,99 +2,92 @@
 // Any issues, requests: https://github.com/KevinDockx/HttpCacheHeaders
 
 using System;
-using System.Net.Http;
 using System.Threading.Tasks;
-using Marvin.Cache.Headers.Sample;
 using Marvin.Cache.Headers.Test.TestStartups;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.TestHost;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Net.Http.Headers;
 using Xunit;
 
-namespace Marvin.Cache.Headers.Test
+namespace Marvin.Cache.Headers.Test;
+
+public class IgnoreCachingFacts
 {
-    public class IgnoreCachingFacts
+    [Fact]
+    public async Task Can_Ignore_Caching_Globally()
     {
-        private readonly IWebHostBuilder _hostBuilder = new WebHostBuilder()
-            .UseStartup<DefaultStartup>();
+        var server = GetTestServer(null, null, options => options.IgnoreCaching = true);
 
-        [Fact]
-        public async Task Can_Ignore_Caching_Globally()
-        {
-            var server = GetTestServer(null, null, options => options.IgnoreCaching = true);
+        using var client = server.CreateClient();
 
-            using var client = server.CreateClient();
+        var response = await client.GetAsync("/");
 
-            var response = await client.GetAsync("/");
+        Assert.True(response.IsSuccessStatusCode);
+        Assert.Empty(response.Headers);
+        Assert.False(string.IsNullOrWhiteSpace(await response.Content.ReadAsStringAsync()));
+    }
 
-            Assert.True(response.IsSuccessStatusCode);
-            Assert.Empty(response.Headers);
-            Assert.False(string.IsNullOrWhiteSpace(await response.Content.ReadAsStringAsync()));
-        }
+    [Fact]
+    public async Task Dont_Ignore_Caching_Per_Default()
+    {
+        var server = GetTestServer(null, null, null);
 
-        private static TestServer GetTestServer(Action<ValidationModelOptions> validationModelOptions, Action<ExpirationModelOptions> expirationModelOptions, Action<MiddlewareOptions> middlewareOptions)
-        {
-            var hostBuilder = new WebHostBuilder()
-                .UseStartup(_ => new ConfiguredStartup(validationModelOptions,expirationModelOptions, middlewareOptions));
+        using var client = server.CreateClient();
 
-            return new TestServer(hostBuilder);
-        }
+        var response = await client.GetAsync("/");
 
-        [Fact]
-        public async Task Dont_Ignore_Caching_Per_Default()
-        {
-            var server = GetTestServer(null, null, null);
+        Assert.True(response.IsSuccessStatusCode);
+        Assert.Collection(response.Headers,
+            pair => Assert.True(pair.Key == HeaderNames.CacheControl),
+            pair => Assert.True(pair.Key == HeaderNames.ETag),
+            pair => Assert.True(pair.Key == HeaderNames.Vary));
+        Assert.False(string.IsNullOrWhiteSpace(await response.Content.ReadAsStringAsync()));
+    }
 
-            using var client = server.CreateClient();
+    [Fact]
+    public async Task Can_Ignore_Status_Codes()
+    {
+        var server = GetTestServer(null, null, options => options.IgnoredStatusCodes = new[] { 400, 500 });
 
-            var response = await client.GetAsync("/");
+        using var client = server.CreateClient();
 
-            Assert.True(response.IsSuccessStatusCode);
-            Assert.Collection(response.Headers,
-                pair => Assert.True(pair.Key == HeaderNames.CacheControl),
-                pair => Assert.True(pair.Key == HeaderNames.ETag),
-                pair => Assert.True(pair.Key == HeaderNames.Vary));
-            Assert.False(string.IsNullOrWhiteSpace(await response.Content.ReadAsStringAsync()));
-        }
-        
-        [Fact]
-        public async Task Can_Ignore_Status_Codes()
-        {
-            var server = GetTestServer(null, null, options => options.IgnoredStatusCodes = new[] { 400, 500 });
+        //Assert ignored status codes
+        var badRequestResponse = await client.GetAsync("/bad-request");
 
-            using var client = server.CreateClient();
+        Assert.Equal(400, (int)badRequestResponse.StatusCode);
+        Assert.Empty(badRequestResponse.Headers);
+        Assert.False(string.IsNullOrWhiteSpace(await badRequestResponse.Content.ReadAsStringAsync()));
 
-            //Assert ignored status codes
-            var badRequestResponse = await client.GetAsync("/bad-request");
-            
-            Assert.Equal(400, (int) badRequestResponse.StatusCode);
-            Assert.Empty(badRequestResponse.Headers);
-            Assert.False(string.IsNullOrWhiteSpace(await badRequestResponse.Content.ReadAsStringAsync()));
+        var serverErrorResponse = await client.GetAsync("/server-error");
 
-            var serverErrorResponse = await client.GetAsync("/server-error");
+        Assert.Equal(500, (int)serverErrorResponse.StatusCode);
+        Assert.Empty(serverErrorResponse.Headers);
+        Assert.False(string.IsNullOrWhiteSpace(await serverErrorResponse.Content.ReadAsStringAsync()));
 
-            Assert.Equal(500, (int) serverErrorResponse.StatusCode);
-            Assert.Empty(serverErrorResponse.Headers);
-            Assert.False(string.IsNullOrWhiteSpace(await serverErrorResponse.Content.ReadAsStringAsync()));
+        //Assert other status codes
+        var notfoundResult = await client.GetAsync("/not-found");
 
-            //Assert other status codes
-            var notfoundResult = await client.GetAsync("/not-found");
-            
-            Assert.Equal(404, (int) notfoundResult.StatusCode);
-            Assert.Collection(notfoundResult.Headers,
-                pair => Assert.True(pair.Key == HeaderNames.CacheControl),
-                pair => Assert.True(pair.Key == HeaderNames.Vary));
-            Assert.False(string.IsNullOrWhiteSpace(await notfoundResult.Content.ReadAsStringAsync()));
+        Assert.Equal(404, (int)notfoundResult.StatusCode);
+        Assert.Collection(notfoundResult.Headers,
+            pair => Assert.True(pair.Key == HeaderNames.CacheControl),
+            pair => Assert.True(pair.Key == HeaderNames.Vary));
+        Assert.False(string.IsNullOrWhiteSpace(await notfoundResult.Content.ReadAsStringAsync()));
 
-            var successResponse = await client.GetAsync("/");
+        var successResponse = await client.GetAsync("/");
 
-            Assert.Equal(200, (int) successResponse.StatusCode);
-            Assert.Collection(successResponse.Headers,
-                pair => Assert.True(pair.Key == HeaderNames.CacheControl),
-                pair => Assert.True(pair.Key == HeaderNames.ETag),
-                pair => Assert.True(pair.Key == HeaderNames.Vary));
-            Assert.False(string.IsNullOrWhiteSpace(await successResponse.Content.ReadAsStringAsync()));
-        }
+        Assert.Equal(200, (int)successResponse.StatusCode);
+        Assert.Collection(successResponse.Headers,
+            pair => Assert.True(pair.Key == HeaderNames.CacheControl),
+            pair => Assert.True(pair.Key == HeaderNames.ETag),
+            pair => Assert.True(pair.Key == HeaderNames.Vary));
+        Assert.False(string.IsNullOrWhiteSpace(await successResponse.Content.ReadAsStringAsync()));
+    }
+
+    private static TestServer GetTestServer(Action<ValidationModelOptions> validationModelOptions, Action<ExpirationModelOptions> expirationModelOptions, Action<MiddlewareOptions> middlewareOptions)
+    {
+        var hostBuilder = new WebHostBuilder()
+            .UseStartup(_ => new ConfiguredStartup(validationModelOptions, expirationModelOptions, middlewareOptions));
+
+        return new TestServer(hostBuilder);
     }
 }

--- a/test/Marvin.Cache.Headers.Test/IgnoreCachingFacts.cs
+++ b/test/Marvin.Cache.Headers.Test/IgnoreCachingFacts.cs
@@ -33,7 +33,7 @@ namespace Marvin.Cache.Headers.Test
             Assert.False(string.IsNullOrWhiteSpace(await response.Content.ReadAsStringAsync()));
         }
 
-        private static TestServer GetTestServer(Action<ValidationModelOptions> validationModelOptions, Action<ExpirationModelOptions> expirationModelOptions, Action<HttpCacheHeadersMiddlewareOptions> middlewareOptions)
+        private static TestServer GetTestServer(Action<ValidationModelOptions> validationModelOptions, Action<ExpirationModelOptions> expirationModelOptions, Action<MiddlewareOptions> middlewareOptions)
         {
             var hostBuilder = new WebHostBuilder()
                 .UseStartup(_ => new ConfiguredStartup(validationModelOptions,expirationModelOptions, middlewareOptions));

--- a/test/Marvin.Cache.Headers.Test/IgnoreCachingFacts.cs
+++ b/test/Marvin.Cache.Headers.Test/IgnoreCachingFacts.cs
@@ -1,0 +1,97 @@
+﻿// Any comments, input: @KevinDockx
+// Any issues, requests: https://github.com/KevinDockx/HttpCacheHeaders
+
+using System.Threading.Tasks;
+using Marvin.Cache.Headers.Test.TestStartups;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Net.Http.Headers;
+using Xunit;
+
+namespace Marvin.Cache.Headers.Test
+{
+    public class IgnoreCachingFacts
+    {
+        private readonly IWebHostBuilder _hostBuilder = new WebHostBuilder()
+            .UseStartup<DefaultStartup>();
+
+        [Fact]
+        public async Task Can_Ignore_Caching_Globally()
+        {
+            _hostBuilder.ConfigureServices(services => services.AddOptions<HttpCacheHeadersMiddlewareOptions>()
+                .Configure(options => options.IgnoreCaching = true));
+
+            var server = new TestServer(_hostBuilder);
+
+            using var client = server.CreateClient();
+
+            var response = await client.GetAsync("/");
+
+            Assert.True(response.IsSuccessStatusCode);
+            Assert.Empty(response.Headers);
+            Assert.False(string.IsNullOrWhiteSpace(await response.Content.ReadAsStringAsync()));
+        }
+
+        [Fact]
+        public async Task Dont_Ignore_Caching_Per_Default()
+        {
+            _hostBuilder.ConfigureServices(services => services.AddOptions<HttpCacheHeadersMiddlewareOptions>());
+
+            var server = new TestServer(_hostBuilder);
+
+            using var client = server.CreateClient();
+
+            var response = await client.GetAsync("/");
+
+            Assert.True(response.IsSuccessStatusCode);
+            Assert.Collection(response.Headers,
+                pair => Assert.True(pair.Key == HeaderNames.CacheControl),
+                pair => Assert.True(pair.Key == HeaderNames.ETag),
+                pair => Assert.True(pair.Key == HeaderNames.Vary));
+            Assert.False(string.IsNullOrWhiteSpace(await response.Content.ReadAsStringAsync()));
+        }
+        
+        [Fact]
+        public async Task Can_Ignore_Status_Codes()
+        {
+            _hostBuilder.ConfigureServices(services => services.AddOptions<HttpCacheHeadersMiddlewareOptions>()
+                .Configure(options => options.IgnoredStatusCodes = new []{ 400, 500 }));
+
+            var server = new TestServer(_hostBuilder);
+
+            using var client = server.CreateClient();
+
+            //Assert ignored status codes
+            var badRequestResponse = await client.GetAsync("/bad-request");
+            
+            Assert.Equal(400, (int) badRequestResponse.StatusCode);
+            Assert.Empty(badRequestResponse.Headers);
+            Assert.False(string.IsNullOrWhiteSpace(await badRequestResponse.Content.ReadAsStringAsync()));
+
+            var serverErrorResponse = await client.GetAsync("/server-error");
+
+            Assert.Equal(500, (int) serverErrorResponse.StatusCode);
+            Assert.Empty(serverErrorResponse.Headers);
+            Assert.False(string.IsNullOrWhiteSpace(await serverErrorResponse.Content.ReadAsStringAsync()));
+
+            //Assert other status codes
+            var notfoundResult = await client.GetAsync("/not-found");
+            
+            Assert.Equal(404, (int) notfoundResult.StatusCode);
+            Assert.Collection(notfoundResult.Headers,
+                pair => Assert.True(pair.Key == HeaderNames.CacheControl),
+                pair => Assert.True(pair.Key == HeaderNames.Vary));
+            Assert.False(string.IsNullOrWhiteSpace(await notfoundResult.Content.ReadAsStringAsync()));
+
+            var successResponse = await client.GetAsync("/");
+
+            Assert.Equal(200, (int) successResponse.StatusCode);
+            Assert.Collection(successResponse.Headers,
+                pair => Assert.True(pair.Key == HeaderNames.CacheControl),
+                pair => Assert.True(pair.Key == HeaderNames.ETag),
+                pair => Assert.True(pair.Key == HeaderNames.Vary));
+            Assert.False(string.IsNullOrWhiteSpace(await successResponse.Content.ReadAsStringAsync()));
+        }
+    }
+}

--- a/test/Marvin.Cache.Headers.Test/Marvin.Cache.Headers.Test.csproj
+++ b/test/Marvin.Cache.Headers.Test/Marvin.Cache.Headers.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>Marvin.Cache.Headers.Test</AssemblyName>
     <PackageId>Marvin.Cache.Headers.Test</PackageId>
     <GenerateRuntimeConfigurationFiles>false</GenerateRuntimeConfigurationFiles>

--- a/test/Marvin.Cache.Headers.Test/TestStartups/ConfiguredStartup.cs
+++ b/test/Marvin.Cache.Headers.Test/TestStartups/ConfiguredStartup.cs
@@ -1,0 +1,74 @@
+// Any comments, input: @KevinDockx
+// Any issues, requests: https://github.com/KevinDockx/HttpCacheHeaders
+
+using System;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Marvin.Cache.Headers.Test.TestStartups
+{
+    public class ConfiguredStartup
+    {
+        private readonly Action<ValidationModelOptions> _validationModelOptions;
+        private readonly Action<ExpirationModelOptions> _expirationModelOptions;
+        private readonly Action<HttpCacheHeadersMiddlewareOptions> _middlewareOptions;
+
+        public ConfiguredStartup(Action<ValidationModelOptions> validationModelOptions, Action<ExpirationModelOptions> expirationModelOptions, Action<HttpCacheHeadersMiddlewareOptions> middlewareOptions)
+        {
+            _validationModelOptions = validationModelOptions;
+            _expirationModelOptions = expirationModelOptions;
+            _middlewareOptions = middlewareOptions;
+            
+            var builder = new ConfigurationBuilder()
+                .AddEnvironmentVariables();
+
+            Configuration = builder.Build();
+        }
+
+        public IConfigurationRoot Configuration { get; }
+
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddControllers();
+
+            services.AddHttpCacheHeaders(_expirationModelOptions, _validationModelOptions, _middlewareOptions);
+        }
+
+        public void Configure(IApplicationBuilder app)
+        {
+            app.UseRouting();
+
+            app.UseHttpCacheHeaders();
+
+            app.UseEndpoints(endpoints =>
+            {
+                endpoints.MapControllerRoute(
+                    name: "default",
+                    pattern: "{controller=Home}/{action=Index}/{id?}");
+            });
+
+            app.Run(async context =>
+            {
+                switch (context.Request.Path)
+                {
+                    case "/bad-request":
+                        context.Response.StatusCode = 400;
+                        break;
+                    case "/server-error":
+                        context.Response.StatusCode = 500;
+                        break;
+                    case "/not-found":
+                        context.Response.StatusCode = 404;
+                        break;
+                    default:
+                        context.Response.StatusCode = 200;
+                        break;
+                }
+                
+                await context.Response.WriteAsync($"Hello from {nameof(DefaultStartup)}");
+            });
+        }
+    }
+}

--- a/test/Marvin.Cache.Headers.Test/TestStartups/ConfiguredStartup.cs
+++ b/test/Marvin.Cache.Headers.Test/TestStartups/ConfiguredStartup.cs
@@ -13,9 +13,9 @@ namespace Marvin.Cache.Headers.Test.TestStartups
     {
         private readonly Action<ValidationModelOptions> _validationModelOptions;
         private readonly Action<ExpirationModelOptions> _expirationModelOptions;
-        private readonly Action<HttpCacheHeadersMiddlewareOptions> _middlewareOptions;
+        private readonly Action<MiddlewareOptions> _middlewareOptions;
 
-        public ConfiguredStartup(Action<ValidationModelOptions> validationModelOptions, Action<ExpirationModelOptions> expirationModelOptions, Action<HttpCacheHeadersMiddlewareOptions> middlewareOptions)
+        public ConfiguredStartup(Action<ValidationModelOptions> validationModelOptions, Action<ExpirationModelOptions> expirationModelOptions, Action<MiddlewareOptions> middlewareOptions)
         {
             _validationModelOptions = validationModelOptions;
             _expirationModelOptions = expirationModelOptions;

--- a/test/Marvin.Cache.Headers.Test/TestStartups/DefaultStartup.cs
+++ b/test/Marvin.Cache.Headers.Test/TestStartups/DefaultStartup.cs
@@ -42,22 +42,6 @@ namespace Marvin.Cache.Headers.Test.TestStartups
 
             app.Run(async context =>
             {
-                switch (context.Request.Path)
-                {
-                    case "/bad-request":
-                        context.Response.StatusCode = 400;
-                        break;
-                    case "/server-error":
-                        context.Response.StatusCode = 500;
-                        break;
-                    case "/not-found":
-                        context.Response.StatusCode = 404;
-                        break;
-                    default:
-                        context.Response.StatusCode = 200;
-                        break;
-                }
-                
                 await context.Response.WriteAsync($"Hello from {nameof(DefaultStartup)}");
             });
         }

--- a/test/Marvin.Cache.Headers.Test/TestStartups/DefaultStartup.cs
+++ b/test/Marvin.Cache.Headers.Test/TestStartups/DefaultStartup.cs
@@ -42,6 +42,22 @@ namespace Marvin.Cache.Headers.Test.TestStartups
 
             app.Run(async context =>
             {
+                switch (context.Request.Path)
+                {
+                    case "/bad-request":
+                        context.Response.StatusCode = 400;
+                        break;
+                    case "/server-error":
+                        context.Response.StatusCode = 500;
+                        break;
+                    case "/not-found":
+                        context.Response.StatusCode = 404;
+                        break;
+                    default:
+                        context.Response.StatusCode = 200;
+                        break;
+                }
+                
                 await context.Response.WriteAsync($"Hello from {nameof(DefaultStartup)}");
             });
         }


### PR DESCRIPTION
This PR adds the possibility to configure the middleware to ignore caching for specific response status codes.

Changes:
- renamed `HttpCacheHeadersMiddlewareOptions` to `MiddlewareOptions` for consistency among option class names
- added and implemented `IgnoreStatusCodes` option
- made `MiddlewareOptions` configurable during service registration (@KevinDockx I made all parameters in the `.AddHttpCacheHeaders()` method optional. That way all overloads of this method can be removed. Otherwise the number of overloads would increase exponentially with every option parameter that gets added)
- add tests for registering `MiddlewareOptions`
- add tests for ignoring caching globally
- add tests for ignoring caching based on status codes
- add predefined collections of status codes that can be used for `IgnoreStatusCodes` option
- update readme with example for `MiddlewareOptions`

closes #108 