### PR TITLE
Add .Net 8 as a target to all projects

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
-    "version": "7.0.400",
-    "rollForward": "latestPatch",
-    "allowPrerelease": false
+    "version": "8.0.100-rc.1.23455.8",
+    "rollForward": "latestMinor",
+    "allowPrerelease": true
   }
 }

--- a/sample/Marvin.Cache.Headers.Sample/Marvin.Cache.Headers.Sample.csproj
+++ b/sample/Marvin.Cache.Headers.Sample/Marvin.Cache.Headers.Sample.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-		<TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+		<TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/src/Marvin.Cache.Headers.DistributedStore.Redis/Marvin.Cache.Headers.DistributedStore.Redis.csproj
+++ b/src/Marvin.Cache.Headers.DistributedStore.Redis/Marvin.Cache.Headers.DistributedStore.Redis.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+		<TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
 		<OutputType>Library</OutputType>
 		<AssemblyName>Marvin.Cache.Headers.DistributedStore.Redis</AssemblyName>
 		<PackageId>Marvin.Cache.Headers.DistributedStore.Redis</PackageId>

--- a/src/Marvin.Cache.Headers.DistributedStore/Marvin.Cache.Headers.DistributedStore.csproj
+++ b/src/Marvin.Cache.Headers.DistributedStore/Marvin.Cache.Headers.DistributedStore.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+		<TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
 		<OutputType>Library</OutputType>
 		<AssemblyName>Marvin.Cache.Headers.DistributedStore</AssemblyName>
 		<PackageId>Marvin.Cache.Headers.DistributedStore</PackageId>

--- a/src/Marvin.Cache.Headers/Marvin.Cache.Headers.csproj
+++ b/src/Marvin.Cache.Headers/Marvin.Cache.Headers.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+		<TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
 		<OutputType>Library</OutputType>
 		<AssemblyName>Marvin.Cache.Headers</AssemblyName>
 		<PackageId>Marvin.Cache.Headers</PackageId>
@@ -24,6 +24,10 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
     <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="7.0.0" />
@@ -34,6 +38,11 @@
     <PackageReference Include="Microsoft.Extensions.Options" Version="7.0.1" />
   </ItemGroup>
   
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="8.0.0-rc.1.23419.4" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.0-rc.1.23419.4" />
+  </ItemGroup>
+
   <PropertyGroup>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 	</PropertyGroup>

--- a/test/Marvin.Cache.Headers.DistributedStore.Redis.Test/Marvin.Cache.Headers.DistributedStore.Redis.Test.csproj
+++ b/test/Marvin.Cache.Headers.DistributedStore.Redis.Test/Marvin.Cache.Headers.DistributedStore.Redis.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <AssemblyName>Marvin.Cache.Headers.DistributedStore.Redis.Test</AssemblyName>
     <PackageId>Marvin.Cache.Headers.DistributedStore.Redis.Test</PackageId>
     <GenerateRuntimeConfigurationFiles>false</GenerateRuntimeConfigurationFiles>

--- a/test/Marvin.Cache.Headers.DistributedStore.Test/Marvin.Cache.Headers.DistributedStore.Test.csproj
+++ b/test/Marvin.Cache.Headers.DistributedStore.Test/Marvin.Cache.Headers.DistributedStore.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <AssemblyName>Marvin.Cache.Headers.DistributedStore.Test</AssemblyName>
     <PackageId>Marvin.Cache.Headers.DistributedStore.Test</PackageId>
     <GenerateRuntimeConfigurationFiles>false</GenerateRuntimeConfigurationFiles>

--- a/test/Marvin.Cache.Headers.Test/Marvin.Cache.Headers.Test.csproj
+++ b/test/Marvin.Cache.Headers.Test/Marvin.Cache.Headers.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <AssemblyName>Marvin.Cache.Headers.Test</AssemblyName>
     <PackageId>Marvin.Cache.Headers.Test</PackageId>
     <GenerateRuntimeConfigurationFiles>false</GenerateRuntimeConfigurationFiles>
@@ -13,6 +13,10 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.9" />
+      </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0-rc.1.23421.29" />
       </ItemGroup>
   
   <ItemGroup>


### PR DESCRIPTION
The PR ensures we are compiling against .Net 8 RC1 as well as .net 6.0 and 7.0.

In order to build this branch, you will need the .Net 8 RC1 SDK installed.